### PR TITLE
Bump the internal dependency versions

### DIFF
--- a/casatables/Cargo.toml
+++ b/casatables/Cargo.toml
@@ -15,7 +15,7 @@ Interfacing to the CASA table format within the Rubbl framework.
 
 [package.metadata.internal_dep_versions]
 rubbl_casatables_impl = "1d861e38cc1a40a6f0c984a58ae3dee54c27d127"
-rubbl_core = "manual:^0.1.2"
+rubbl_core = "thiscommit:2020-12-15:EiT8sa0a"
 
 [dependencies]
 byteorder = "^1.3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,7 @@ Facade crate and CLI interface for the Rubbl astrophysics data analysis framewor
 """
 
 [package.metadata.internal_dep_versions]
-rubbl_core = "manual:^0.1.2"
+rubbl_core = "thiscommit:2020-12-15:re8eeQu5"
 
 [dependencies]
 clap = "^2.33"

--- a/fits/Cargo.toml
+++ b/fits/Cargo.toml
@@ -9,8 +9,8 @@ license = "MIT"
 edition = "2018"
 
 [package.metadata.internal_dep_versions]
-rubbl_core = "manual:^0.1.2"
-rubbl_visdata = "manual:^0.1.0"
+rubbl_core = "thiscommit:2020-12-15:peif3Eng"
+rubbl_visdata = "thiscommit:2020-12-15:Ox8roFai"
 
 [dependencies]
 byteorder = "^1.3"

--- a/miriad/Cargo.toml
+++ b/miriad/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2018"
 [package.metadata]
 
 [package.metadata.internal_dep_versions]
-rubbl_core = "manual:^0.1.2"
-rubbl_visdata = "manual:^0.1.0"
+rubbl_core = "thiscommit:2020-12-15:aishi6Ae"
+rubbl_visdata = "thiscommit:2020-12-15:Rohw0kei"
 
 [dependencies]
 byteorder = "^1.3"

--- a/visdata/Cargo.toml
+++ b/visdata/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 edition = "2018"
 
 [package.metadata.internal_dep_versions]
-rubbl_core = "manual:^0.1.2"
+rubbl_core = "thiscommit:2020-12-15:Fiequ0wa"
 
 [dependencies]
 rubbl_core = { path = "../core", version ="0.0.0-dev.0"}


### PR DESCRIPTION
Looks like we need to do this to get the internal dependencies to work on release.