### PR TITLE
WIP. failure -> thiserror/anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0df63cb2955042487fad3aefd2c6e3ae7389ac5dc1beb28921de0b69f779d4"
+
+[[package]]
 name = "arrayvec"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,9 +363,9 @@ checksum = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.5"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90cf5f418035b98e655e9cdb225047638296b862b42411c4e45bb88d700f7fc0"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -436,10 +442,10 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 name = "rubbl"
 version = "0.0.0-dev.0"
 dependencies = [
+ "anyhow",
  "clap",
- "failure",
- "failure_derive",
  "rubbl_core",
+ "thiserror",
 ]
 
 [[package]]
@@ -449,8 +455,6 @@ dependencies = [
  "byteorder",
  "cc",
  "clap",
- "failure",
- "failure_derive",
  "itertools",
  "ndarray",
  "nom",
@@ -458,6 +462,7 @@ dependencies = [
  "pbr",
  "rubbl_casatables_impl",
  "rubbl_core",
+ "thiserror",
 ]
 
 [[package]]
@@ -471,25 +476,25 @@ dependencies = [
 name = "rubbl_core"
 version = "0.0.0-dev.0"
 dependencies = [
+ "anyhow",
  "byteorder",
  "clap",
- "failure",
- "failure_derive",
  "ndarray",
  "num-complex",
  "termcolor",
+ "thiserror",
 ]
 
 [[package]]
 name = "rubbl_fits"
 version = "0.0.0-dev.0"
 dependencies = [
+ "anyhow",
  "byteorder",
  "clap",
- "failure",
- "failure_derive",
  "rubbl_core",
  "rubbl_visdata",
+ "thiserror",
 ]
 
 [[package]]
@@ -563,9 +568,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.5"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
+checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -606,6 +611,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/casatables/Cargo.toml
+++ b/casatables/Cargo.toml
@@ -20,8 +20,6 @@ rubbl_core = "thiscommit:2020-12-15:EiT8sa0a"
 [dependencies]
 byteorder = "^1.4"
 clap = "^2.33"
-failure = "^0.1"
-failure_derive = "^0.1"
 itertools = "^0.10"
 ndarray = "^0.15"
 nom = "^6.1"
@@ -29,6 +27,7 @@ num-traits = "^0.2"
 pbr = "^1.0"
 rubbl_casatables_impl = { version ="0.0.0-dev.0", path = "../casatables_impl" }
 rubbl_core = { version ="0.0.0-dev.0", path = "../core" }
+thiserror = "^1.0"
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,7 @@ Facade crate and CLI interface for the Rubbl astrophysics data analysis framewor
 rubbl_core = "thiscommit:2020-12-15:re8eeQu5"
 
 [dependencies]
+anyhow = "^1.0"
 clap = "^2.33"
-failure = "^0.1"
-failure_derive = "^0.1"
 rubbl_core = { version ="0.0.0-dev.0", path = "../core" }
+thiserror = "^1.0"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,15 +11,14 @@ Heavily modeled on Cargo's implementation of the same sort of functionality.
 */
 
 use clap::{crate_version, App, AppSettings, Arg, ArgMatches, SubCommand};
-use failure::Error;
-use failure_derive::Fail;
 use rubbl_core::{
     notify::{ClapNotificationArgsExt, NotificationBackend},
     Result,
 };
 use std::{
     collections::BTreeSet,
-    env, fs,
+    env,
+    fs,
     os::unix::process::CommandExt,
     path::{Path, PathBuf},
     process,
@@ -27,8 +26,8 @@ use std::{
 
 // Some error help.
 
-#[derive(Fail, Debug)]
-#[fail(display = "no such sub-command `{}`", _0)]
+#[derive(thiserror::Error, Debug)]
+#[error("no such sub-command `{0}`")]
 pub struct NoSuchSubcommandError(String);
 
 fn main() {
@@ -125,7 +124,7 @@ fn do_external(cmd: &str, matches: &ArgMatches, _nbe: &mut dyn NotificationBacke
 
 /// Try to re-execute the process using the executable corresponding to the
 /// named sub-command. If this function returns, something went wrong.
-fn try_exec_subcommand(cmd: &str, args: &[&str]) -> Error {
+fn try_exec_subcommand(cmd: &str, args: &[&str]) -> anyhow::Error {
     let command_exe = format!("rubbl-{}{}", cmd, env::consts::EXE_SUFFIX);
     let path = search_directories()
         .iter()

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,10 +14,10 @@ Core types and traits for Rubbl, a Rust package for astrophysics.
 """
 
 [dependencies]
+anyhow = "^1.0"
 byteorder = "^1.4"
 clap = "^2.33"
-failure = "^0.1"
-failure_derive = "^0.1"
 ndarray = "^0.15"
 num-complex = "^0.4"
 termcolor = "^1.1"
+thiserror = "^1.0"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,7 +13,8 @@ the Rubbl framework.
 #![deny(missing_docs)]
 
 // convenience re-exports
-pub use failure::{Error, Fail, ResultExt};
+use anyhow::Context;
+pub use anyhow::Error;
 pub use ndarray::Array;
 pub use num_complex::Complex;
 
@@ -21,7 +22,7 @@ pub use num_complex::Complex;
 ///
 /// Attempts an operation that returns a Result and returns its Ok value if
 /// the operation is successful. If not, it returns an Err value of type
-/// `failure::Context` that includes explanatory text formatted using the
+/// `anyhow::Context` that includes explanatory text formatted using the
 /// `format!` macro and chains to the causative error. Example:
 ///
 /// ```rust,ignore
@@ -34,7 +35,7 @@ pub use num_complex::Complex;
 macro_rules! ctry {
     ($op:expr ; $( $chain_fmt_args:expr ),*) => {
         {
-            use $crate::ResultExt;
+            use $crate::Error;
             $op.with_context(|_| format!($( $chain_fmt_args ),*))?
         }
     }
@@ -46,4 +47,4 @@ pub mod num;
 
 /// A convenience Result type whose error half is fixed to be
 /// `failure::Error`.
-pub type Result<T> = ::std::result::Result<T, failure::Error>;
+pub type Result<T> = ::std::result::Result<T, anyhow::Error>;

--- a/core/src/notify/mod.rs
+++ b/core/src/notify/mod.rs
@@ -17,8 +17,8 @@ engine. (Which the author of this module also wrote.)
 #[macro_use]
 pub mod termcolor;
 
+use anyhow::Error;
 use clap;
-use failure::Error;
 use std::cmp;
 use std::fmt::Arguments;
 use std::result::Result as StdResult;
@@ -201,9 +201,9 @@ impl BufferingNotificationBackend {
 impl NotificationBackend for BufferingNotificationBackend {
     fn notify(&mut self, kind: NotificationKind, args: Arguments, err: Option<Error>) {
         self.buf.push(NotificationData {
-            kind: kind,
+            kind,
             text: format!("{}", args),
-            err: err,
+            err,
         });
     }
 }

--- a/core/src/notify/termcolor.rs
+++ b/core/src/notify/termcolor.rs
@@ -13,7 +13,7 @@ engine. (Which the author of this module also wrote.)
 // TODO: make this module a feature that can be disabled if the user doesn't want to
 // link with termcolor
 
-use failure::Error;
+use anyhow::Error;
 use std::fmt::Arguments;
 use std::io::Write;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
@@ -55,14 +55,14 @@ impl TermcolorNotificationBackend {
         fatal_spec.set_fg(Some(Color::Red)).set_bold(true);
 
         TermcolorNotificationBackend {
-            chatter: chatter,
+            chatter,
             stdout: StandardStream::stdout(ColorChoice::Auto),
             stderr: StandardStream::stderr(ColorChoice::Auto),
-            note_spec: note_spec,
+            note_spec,
             //highlight_spec: highlight_spec,
-            warning_spec: warning_spec,
-            severe_spec: severe_spec,
-            fatal_spec: fatal_spec,
+            warning_spec,
+            severe_spec,
+            fatal_spec,
         }
     }
 
@@ -135,7 +135,7 @@ impl TermcolorNotificationBackend {
         let mut prefix = "error:";
         let err = err.into();
 
-        for fail in err.iter_chain() {
+        for fail in err.chain() {
             self.generic_message(
                 NotificationKind::Severe,
                 Some(prefix),
@@ -144,15 +144,15 @@ impl TermcolorNotificationBackend {
             prefix = "caused by:";
         }
 
-        let backtrace = err.backtrace();
-        self.generic_message(
-            NotificationKind::Severe,
-            Some("debugging:"),
-            format_args!("backtrace follows:"),
-        );
-        self.with_stream(NotificationKind::Severe, |s| {
-            writeln!(s, "{:?}", backtrace).expect("backtrace dump failed");
-        });
+        // let backtrace = err.backtrace();
+        // self.generic_message(
+        //     NotificationKind::Severe,
+        //     Some("debugging:"),
+        //     format_args!("backtrace follows:"),
+        // );
+        // self.with_stream(NotificationKind::Severe, |s| {
+        //     writeln!(s, "{:?}", backtrace).expect("backtrace dump failed");
+        // });
     }
 }
 
@@ -161,15 +161,15 @@ impl NotificationBackend for TermcolorNotificationBackend {
         self.generic_message(kind, None, args);
 
         if let Some(e) = err {
-            for fail in e.iter_chain() {
+            for fail in e.chain() {
                 self.generic_message(kind, Some("caused by:"), format_args!("{}", fail));
             }
 
-            let backtrace = e.backtrace();
-            self.generic_message(kind, Some("debugging:"), format_args!("backtrace follows:"));
-            self.with_stream(kind, |s| {
-                writeln!(s, "{:?}", backtrace).expect("backtrace dump failed");
-            });
+            // let backtrace = e.backtrace();
+            // self.generic_message(kind, Some("debugging:"), format_args!("backtrace follows:"));
+            // self.with_stream(kind, |s| {
+            //     writeln!(s, "{:?}", backtrace).expect("backtrace dump failed");
+            // });
         }
     }
 }

--- a/core/src/num.rs
+++ b/core/src/num.rs
@@ -3,16 +3,13 @@
 
 //! General helpers for numerics.
 
-use failure_derive::Fail;
 use ndarray::{IntoDimension, Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6};
+use thiserror::Error;
 
 /// An error type used when two arrays should have the same dimensionality,
 /// but do not.
-#[derive(Fail, Debug)]
-#[fail(
-    display = "Expected a {}-dimensional array, but got one with {} dimensions",
-    expected, actual
-)]
+#[derive(Error, Debug)]
+#[error("Expected a {expected}-dimensional array, but got one with {actual} dimensions")]
 pub struct DimensionMismatchError {
     /// The number of dimensions that the array was expected to have.
     pub expected: usize,

--- a/fits/Cargo.toml
+++ b/fits/Cargo.toml
@@ -18,9 +18,9 @@ rubbl_core = "thiscommit:2020-12-15:peif3Eng"
 rubbl_visdata = "thiscommit:2020-12-15:Ox8roFai"
 
 [dependencies]
+anyhow = "^1.0"
 byteorder = "^1.4"
 clap = "^2.33"
-failure = "^0.1"
-failure_derive = "^0.1"
 rubbl_core = { path = "../core", version ="0.0.0-dev.0"}
 rubbl_visdata = { path = "../visdata", version ="0.0.0-dev.0"}
+thiserror = "^1.0"

--- a/fits/examples/fitsdump.rs
+++ b/fits/examples/fitsdump.rs
@@ -1,8 +1,8 @@
 //! Decode a FITS file in a very low-level way, and report how long it took.
 //! This should basically just be a test of the system's I/O throughput.
 
+use anyhow::Context;
 use clap::{App, Arg};
-use failure::{Error, ResultExt};
 use rubbl_core::io::AligningReader;
 use rubbl_fits::LowLevelFitsItem;
 use std::ffi::OsStr;
@@ -38,14 +38,14 @@ fn main() {
     });
 }
 
-fn inner(path: &OsStr) -> Result<i32, Error> {
-    let file = fs::File::open(path).context("error opening file")?;
+fn inner(path: &OsStr) -> Result<i32, anyhow::Error> {
+    let file = fs::File::open(path).with_context(|| "error opening file")?;
     let mut dec = rubbl_fits::FitsDecoder::new(AligningReader::new(file));
     let t0 = Instant::now();
     let mut last_was_data = false;
 
     loop {
-        match dec.next().context("error parsing FITS")? {
+        match dec.next().with_context(|| "error parsing FITS")? {
             None => {
                 break;
             }

--- a/fits/src/lib.rs
+++ b/fits/src/lib.rs
@@ -8,24 +8,109 @@
 
 #![deny(missing_docs)]
 
-use failure::Error;
-use failure_derive::Fail;
 use rubbl_core::io::EofReadExactExt;
 use std::io::prelude::*;
 use std::io::SeekFrom;
 use std::str;
-
-// Define this before any submodules are parsed.
-macro_rules! fitserr {
-    ($( $fmt_args:expr ),*) => {
-        Err($crate::FitsFormatError(format!($( $fmt_args ),*)).into())
-    }
-}
+use thiserror::Error;
 
 /// An error type for when a FITS file is malformed.
-#[derive(Debug, Fail)]
-#[fail(display = "{}", _0)]
-pub struct FitsFormatError(String);
+#[allow(missing_docs)]
+#[derive(Debug, Error)]
+pub enum FitsError {
+    #[error("FITS stream should be a multiple of 2880 bytes long; got {0}")]
+    Not2880Multiple(u64),
+
+    #[error("file does not appear to be in FITS format")]
+    InvalidFormat,
+
+    #[error("second FITS header must be BITPIX")]
+    SecondHeaderNotBitpix,
+
+    #[error("unsupported BITPIX value in FITS file: {0}")]
+    UnsupportedBitpix(isize),
+
+    #[error("third FITS header must be NAXIS")]
+    ThirdHeaderNotNaxis,
+
+    #[error("unsupported NAXIS value in FITS file: {0}")]
+    BadNaxisValue(isize),
+
+    #[error("illegal negative FITS GCOUNT value")]
+    NegativeGcountValue,
+
+    #[error("illegal extension HDU without EXTNAME header")]
+    ExtHduWithoutExtname,
+
+    #[error("illegal negative FITS group size")]
+    NegativeGroupSize,
+
+    #[error("truncated-looking FITS file")]
+    Truncated,
+
+    #[error("FITS data stream does not begin with \"SIMPLE = T\" marker")]
+    NotSimple,
+
+    #[error("illegal header keyword ASCII code {0}")]
+    BadHeaderAscii(u8),
+
+    #[error("malformed FITS header keyword")]
+    MalformedHeader,
+
+    #[error("{0}")]
+    FitsFormat(#[from] FitsFormatError),
+
+    #[error("{0}")]
+    IO(#[from] std::io::Error),
+}
+
+/// An error type associated with problems that might occur when reading a FITS
+/// file.
+#[allow(missing_docs)]
+#[derive(Debug, Error)]
+pub enum FitsFormatError {
+    #[error("expected opening equals and quote in fixed-format string record")]
+    UnexpectedStrSep,
+
+    #[error("illegal non-printable-ASCII value in fixed-format string record")]
+    IllegalAscii,
+
+    #[error("illegal ASCII value {0} after string in fixed-format string record")]
+    IllegalAsciiAfterString(u8),
+
+    #[error("illegal ASCII value {0} after single quote in fixed-format string record")]
+    IllegalAsciiAfterQuote(u8),
+
+    #[error("illegal unterminated fixed-format string record")]
+    Unterminated,
+
+    #[error("expected space or slash in byte 30 of fixed-format integer record")]
+    UnexpectedByte30,
+
+    #[error("empty record that should have been a fixed-format integer")]
+    EmptyRecordInt,
+
+    #[error("expected digit but got ASCII {0:?} in fixed-format integer")]
+    ExpectedDigit(u8),
+
+    #[error("malformed FITS NAXIS header")]
+    MalformedNaxis,
+
+    #[error("expected digit but got ASCII {0:?} in NAXIS header")]
+    ExpectedDigitNaxisHeader(u8),
+
+    #[error("expected space but got ASCII {0:?} in NAXIS header")]
+    ExpectedSpaceNaxisHeader(u8),
+
+    #[error("misnumbered NAXIS header (expected {expected}, got {got})")]
+    MisnumberedNaxis { expected: usize, got: usize },
+
+    #[error("illegal negative NAXIS{value} value {n}")]
+    NegativeNaxisValue { value: usize, n: isize },
+
+    #[error("{0}")]
+    Utf8(#[from] std::str::Utf8Error),
+}
 
 /// A chunk of FITS file data, as produced by our low-level decoder.
 #[derive(Clone, Debug)]
@@ -144,7 +229,7 @@ impl<R: Read> FitsDecoder<R> {
     /// Create a new decoder that gets data from the Read type passed as an argument.
     pub fn new(inner: R) -> Self {
         Self {
-            inner: inner,
+            inner,
             buf: [0; 2880],
             offset: 2880,
             state: DecoderState::Beginning,
@@ -161,12 +246,12 @@ impl<R: Read> FitsDecoder<R> {
     /// Get the next item in the FITS stream.
     ///
     /// Returns Ok(None) at an expected EOF.
-    pub fn next<'a>(&'a mut self) -> Result<Option<LowLevelFitsItem<'a>>, Error> {
+    pub fn next<'a>(&'a mut self) -> Result<Option<LowLevelFitsItem<'a>>, FitsError> {
         if self.offset == 2880 {
-            if !self.inner.eof_read_exact::<Error>(&mut self.buf)? {
+            if !self.inner.eof_read_exact::<FitsError>(&mut self.buf)? {
                 if self.state != DecoderState::NewHdu && self.state != DecoderState::SpecialRecords
                 {
-                    return fitserr!("truncated-looking FITS file");
+                    return Err(FitsError::Truncated);
                 }
 
                 return Ok(None);
@@ -204,7 +289,7 @@ impl<R: Read> FitsDecoder<R> {
 
         if self.state == DecoderState::Beginning {
             if &record[..FITS_MARKER.len()] != FITS_MARKER {
-                return fitserr!("FITS data stream does not begin with \"SIMPLE = T\" marker");
+                return Err(FitsError::NotSimple);
             }
 
             self.state = DecoderState::SizingHeaders;
@@ -240,14 +325,14 @@ impl<R: Read> FitsDecoder<R> {
                     -32 => Bitpix::F32,
                     -64 => Bitpix::F64,
                     other => {
-                        return fitserr!("unsupported BITPIX value in FITS file: {}", other);
+                        return Err(FitsError::UnsupportedBitpix(other));
                     }
                 };
             } else if &record[..NAXIS_MARKER.len()] == NAXIS_MARKER {
                 let naxis = parse_fixed_int(record)?;
 
                 if naxis < 0 || naxis > 999 {
-                    return fitserr!("unsupported NAXIS value in FITS file: {}", naxis);
+                    return Err(FitsError::BadNaxisValue(naxis));
                 }
 
                 self.naxis.clear();
@@ -273,7 +358,7 @@ impl<R: Read> FitsDecoder<R> {
                 let n = parse_fixed_int(record)?;
 
                 if n < 0 {
-                    return fitserr!("illegal negative FITS GCOUNT value");
+                    return Err(FitsError::NegativeGcountValue);
                 }
 
                 self.gcount = n as usize;
@@ -285,7 +370,7 @@ impl<R: Read> FitsDecoder<R> {
                 };
 
                 if group_size < 0 {
-                    return fitserr!("illegal negative FITS group size");
+                    return Err(FitsError::NegativeGroupSize);
                 }
 
                 self.offset = 2880;
@@ -318,7 +403,7 @@ impl<R: Read> FitsDecoder<R> {
                         break;
                     }
                     other => {
-                        return fitserr!("illegal header keyword ASCII code {}", other);
+                        return Err(FitsError::BadHeaderAscii(other));
                     }
                 }
 
@@ -327,7 +412,7 @@ impl<R: Read> FitsDecoder<R> {
 
             while i < 8 {
                 if record[i] != b' ' {
-                    return fitserr!("malformed FITS header keyword");
+                    return Err(FitsError::MalformedHeader);
                 }
 
                 i += 1;
@@ -401,14 +486,11 @@ pub struct ParsedHdu {
 
 impl<R: Read + Seek> FitsParser<R> {
     /// Parse the headers of a FITS file.
-    pub fn new(mut inner: R) -> Result<Self, Error> {
+    pub fn new(mut inner: R) -> Result<Self, FitsError> {
         let file_size = inner.seek(SeekFrom::End(0))?;
 
         if file_size % 2880 != 0 {
-            return fitserr!(
-                "FITS stream should be a multiple of 2880 bytes long; got {}",
-                file_size
-            );
+            return Err(FitsError::Not2880Multiple(file_size));
         }
 
         inner.seek(SeekFrom::Start(0))?;
@@ -439,7 +521,7 @@ impl<R: Read + Seek> FitsParser<R> {
 
             if hdus.len() == 0 {
                 if &buf[..FITS_MARKER.len()] != FITS_MARKER {
-                    return fitserr!("file does not appear to be in FITS format");
+                    return Err(FitsError::InvalidFormat);
                 }
             } else {
                 if &buf[..XTENSION_MARKER.len()] != XTENSION_MARKER {
@@ -463,7 +545,7 @@ impl<R: Read + Seek> FitsParser<R> {
                 let record = &buf[80..160];
 
                 if &record[..BITPIX_MARKER.len()] != BITPIX_MARKER {
-                    return fitserr!("second FITS header must be BITPIX");
+                    return Err(FitsError::SecondHeaderNotBitpix);
                 }
 
                 parse_fixed_int(record)?
@@ -477,7 +559,7 @@ impl<R: Read + Seek> FitsParser<R> {
                 -32 => Bitpix::F32,
                 -64 => Bitpix::F64,
                 other => {
-                    return fitserr!("unsupported BITPIX value in FITS file: {}", other);
+                    return Err(FitsError::UnsupportedBitpix(other));
                 }
             };
 
@@ -489,14 +571,14 @@ impl<R: Read + Seek> FitsParser<R> {
                 let record = &buf[160..240];
 
                 if &record[..NAXIS_MARKER.len()] != NAXIS_MARKER {
-                    return fitserr!("third FITS header must be NAXIS");
+                    return Err(FitsError::ThirdHeaderNotNaxis);
                 }
 
                 parse_fixed_int(record)?
             };
 
             if naxis_value < 0 || naxis_value > 999 {
-                return fitserr!("unsupported NAXIS value in FITS file: {}", naxis_value);
+                return Err(FitsError::BadNaxisValue(naxis_value));
             }
 
             naxis.reserve(naxis_value as usize);
@@ -529,7 +611,7 @@ impl<R: Read + Seek> FitsParser<R> {
                     let n = parse_fixed_int(record)?;
 
                     if n < 0 {
-                        return fitserr!("illegal negative FITS GCOUNT value");
+                        return Err(FitsError::NegativeGcountValue);
                     }
 
                     gcount = n as usize;
@@ -551,7 +633,7 @@ impl<R: Read + Seek> FitsParser<R> {
                 match extname {
                     Some(s) => s,
                     None => {
-                        return fitserr!("illegal extension HDU without EXTNAME header");
+                        return Err(FitsError::ExtHduWithoutExtname);
                     }
                 }
             };
@@ -563,7 +645,7 @@ impl<R: Read + Seek> FitsParser<R> {
             let group_size = pcount + naxis.iter().fold(1, |p, n| p * n) as isize;
 
             if group_size < 0 {
-                return fitserr!("illegal negative FITS group size");
+                return Err(FitsError::NegativeGroupSize);
             }
 
             let data_size = bitpix.n_bytes() * gcount * group_size as usize;
@@ -644,9 +726,9 @@ impl ParsedHdu {
     }
 }
 
-fn parse_fixed_int(record: &[u8]) -> Result<isize, Error> {
+fn parse_fixed_int(record: &[u8]) -> Result<isize, FitsFormatError> {
     if record[30] != b' ' && record[30] != b'/' {
-        return fitserr!("expected space or slash in byte 30 of fixed-format integer record");
+        return Err(FitsFormatError::UnexpectedByte30);
     }
 
     let mut i = 10;
@@ -660,7 +742,7 @@ fn parse_fixed_int(record: &[u8]) -> Result<isize, Error> {
     }
 
     if i == 30 {
-        return fitserr!("empty record that should have been a fixed-format integer");
+        return Err(FitsFormatError::EmptyRecordInt);
     }
 
     let mut negate = false;
@@ -673,7 +755,7 @@ fn parse_fixed_int(record: &[u8]) -> Result<isize, Error> {
     }
 
     if i == 30 {
-        return fitserr!("empty record that should have been a fixed-format integer");
+        return Err(FitsFormatError::EmptyRecordInt);
     }
 
     let mut value = 0;
@@ -711,10 +793,7 @@ fn parse_fixed_int(record: &[u8]) -> Result<isize, Error> {
                 value += 9;
             }
             other => {
-                return fitserr!(
-                    "expected digit but got ASCII {:?} in fixed-format integer",
-                    other
-                );
+                return Err(FitsFormatError::ExpectedDigit(other));
             }
         }
 
@@ -757,9 +836,9 @@ fn fixed_int_parsing() {
     assert!(parse_fixed_int(r).is_err());
 }
 
-fn parse_fixed_string(record: &[u8]) -> Result<String, Error> {
+fn parse_fixed_string(record: &[u8]) -> Result<String, FitsFormatError> {
     if &record[8..11] != b"= '" {
-        return fitserr!("expected opening equals and quote in fixed-format string record");
+        return Err(FitsFormatError::UnexpectedStrSep);
     }
 
     let mut buf = [0u8; 69];
@@ -782,7 +861,7 @@ fn parse_fixed_string(record: &[u8]) -> Result<String, Error> {
         let c = record[i + 11];
 
         if c < 0x20 || c > 0x7E {
-            return fitserr!("illegal non-printable-ASCII value in fixed-format string record");
+            return Err(FitsFormatError::IllegalAscii);
         }
 
         match state {
@@ -819,11 +898,7 @@ fn parse_fixed_string(record: &[u8]) -> Result<String, Error> {
                 }
 
                 other => {
-                    return fitserr!(
-                        "illegal ASCII value {} after single quote in \
-                         fixed-format string record",
-                        other
-                    );
+                    return Err(FitsFormatError::IllegalAsciiAfterQuote(other));
                 }
             },
 
@@ -835,11 +910,7 @@ fn parse_fixed_string(record: &[u8]) -> Result<String, Error> {
                 }
 
                 other => {
-                    return fitserr!(
-                        "illegal ASCII value {} after string in \
-                         fixed-format string record",
-                        other
-                    );
+                    return Err(FitsFormatError::IllegalAsciiAfterString(other));
                 }
             },
 
@@ -850,7 +921,7 @@ fn parse_fixed_string(record: &[u8]) -> Result<String, Error> {
     }
 
     if state == State::Chars {
-        return fitserr!("illegal unterminated fixed-format string record");
+        return Err(FitsFormatError::Unterminated);
     }
 
     Ok(if !any_chars {
@@ -894,13 +965,13 @@ fn fixed_string_parsing() {
 /// Returns Ok(true) if this record in question was the appropriate NAXISnnn
 /// header; Ok(false) if it was some other valid-looking header; Err(_) if it
 /// looks like it should have been a NAXIS header but something went wrong.
-fn accumulate_naxis_value(record: &[u8], naxis: &mut Vec<usize>) -> Result<bool, Error> {
+fn accumulate_naxis_value(record: &[u8], naxis: &mut Vec<usize>) -> Result<bool, FitsFormatError> {
     if &record[..5] != b"NAXIS" {
         return Ok(false); // Th
     }
 
     if &record[8..10] != b"= " {
-        return fitserr!("malformed FITS NAXIS header");
+        return Err(FitsFormatError::MalformedNaxis);
     }
 
     let mut value = 0;
@@ -943,7 +1014,7 @@ fn accumulate_naxis_value(record: &[u8], naxis: &mut Vec<usize>) -> Result<bool,
                 value += 9;
             }
             other => {
-                return fitserr!("expected digit but got ASCII {:?} in NAXIS header", other);
+                return Err(FitsFormatError::ExpectedDigitNaxisHeader(other));
             }
         }
 
@@ -952,27 +1023,23 @@ fn accumulate_naxis_value(record: &[u8], naxis: &mut Vec<usize>) -> Result<bool,
 
     while i < 8 {
         if record[i] != b' ' {
-            return fitserr!(
-                "expected space but got ASCII {:?} in NAXIS header",
-                record[i]
-            );
+            return Err(FitsFormatError::ExpectedSpaceNaxisHeader(record[i]));
         }
 
         i += 1;
     }
 
     if value != naxis.len() + 1 {
-        return fitserr!(
-            "misnumbered NAXIS header (expected {}, got {})",
-            naxis.len() + 1,
-            value
-        );
+        return Err(FitsFormatError::MisnumberedNaxis {
+            expected: naxis.len() + 1,
+            got: value,
+        });
     }
 
     let n = parse_fixed_int(record)?;
 
     if n < 0 {
-        return fitserr!("illegal negative NAXIS{} value {}", value, n);
+        return Err(FitsFormatError::NegativeNaxisValue { value, n });
     }
 
     naxis.push(n as usize);


### PR DESCRIPTION
This is my work-in-progress on converting `rubbl`'s usage of `failure` to using `thiserror` and/or `anyhow` (`anyhow` is good for "catch all" scenarios, whereas `thiserror` is good for writing nice Rust errors that can be propagated). This is beneficial, because `failure` has apparently been deprecated, and by using `thiserror` `Error` types, one can use `?` on functions that return result types.

The current state of this branch does not compile, but I think I'd like your input before I continue; it's getting a little subjective. Hopefully it's easy to see what's going on -- it looks like the `failure` API is very similar to `thiserror`/`anyhow`, but I was still struggling on a couple of little things.

You can let me know what you think, and I can have another crack at getting things fully converted.