### PR TITLE
add table put_table_keyword

### DIFF
--- a/casatables/src/glue.cc
+++ b/casatables/src/glue.cc
@@ -694,7 +694,7 @@ extern "C" {
             case casacore::TpTable: {
                 rec.defineTable(
                     bridge_string(kw_name),
-                    (const casacore::Table &)(data)
+                    *((const casacore::Table *)(data))
                 );
                 break;
             }

--- a/casatables/src/glue.cc
+++ b/casatables/src/glue.cc
@@ -683,6 +683,32 @@ extern "C" {
     }
 
     int
+    table_put_keyword(GlueTable &table, const StringBridge &kw_name, 
+                      const GlueDataType data_type, void *data, ExcInfo &exc)
+    {
+        try {
+            casacore::TableRecord &rec = table.rwKeywordSet();
+
+            switch(data_type) {
+
+            case casacore::TpTable: {
+                rec.defineTable(
+                    bridge_string(kw_name),
+                    (const casacore::Table &)(data)
+                );
+                break;
+            }
+            default:
+                throw std::runtime_error("unhandled keyword data type");
+            }
+        } catch (...) {
+            handle_exception(exc);
+            return 1;
+        }
+        return 0;
+    }
+
+    int
     table_copy_rows(const GlueTable &source, GlueTable &dest, ExcInfo &exc)
     {
         try {

--- a/casatables/src/glue.h
+++ b/casatables/src/glue.h
@@ -16,7 +16,8 @@
 #ifndef CASA_TYPES_ALREADY_DECLARED
 
 // copied from casa/Utilities/DataType.h:
-typedef enum GlueDataType {
+typedef enum GlueDataType
+{
     TpBool,
     TpChar,
     TpUChar,
@@ -67,12 +68,14 @@ typedef struct GlueTableDesc GlueTableDesc;
 // to use C++->Rust callbacks to be able to copy string contents before they
 // are deallocated at the C++ layer.
 
-typedef struct StringBridge {
+typedef struct StringBridge
+{
     const void *data;
     unsigned long n_bytes;
 } StringBridge;
 
-typedef struct ExcInfo {
+typedef struct ExcInfo
+{
     char message[512];
 } ExcInfo;
 
@@ -84,13 +87,15 @@ typedef void (*StringBridgeCallback)(const StringBridge *name, void *ctxt);
 // additional information we'd like to to transfer.
 typedef void (*KeywordInfoCallback)(const StringBridge *name, GlueDataType dtype, void *ctxt);
 
-typedef enum TableOpenMode {
+typedef enum TableOpenMode
+{
     TOM_OPEN_READONLY = 1,
     TOM_OPEN_RW = 2,
     TOM_CREATE = 3,
 } TableOpenMode;
 
-typedef enum TableCreateMode {
+typedef enum TableCreateMode
+{
     // create table
     TCM_NEW = 1,
     // create table (may not exist)
@@ -99,7 +104,8 @@ typedef enum TableCreateMode {
     TCM_SCRATCH = 3,
 } TableCreateMode;
 
-typedef enum TableDescCreateMode {
+typedef enum TableDescCreateMode
+{
     //    Create a new table description file.
     //    The TableDesc destructor will write the table description into the file.
     TDM_NEW,
@@ -124,14 +130,24 @@ typedef enum TableDescCreateMode {
     //    Delete the table description file. This gets done by the destructor.
 } TableDescOption;
 
-extern "C" {
+extern "C"
+{
     int data_type_get_element_size(const GlueDataType ty);
 
-    GlueTableDesc *tabledesc_create(const StringBridge &type, const TableDescCreateMode mode, ExcInfo &exc);
-    GlueTableDesc *tabledesc_add_scalar_column( GlueTableDesc &table_desc, GlueDataType data_type, const StringBridge &col_name, const StringBridge &comment, bool direct, bool undefined, ExcInfo &exc);
-    GlueTableDesc *tabledesc_add_array_column( GlueTableDesc &table_desc, GlueDataType data_type, const StringBridge &col_name, const StringBridge &comment, bool direct, bool undefined, ExcInfo &exc);
-    GlueTableDesc *tabledesc_add_fixed_array_column( GlueTableDesc &table_desc, GlueDataType data_type, const StringBridge &col_name, const StringBridge &comment, const unsigned long n_dims, const unsigned long *dims, bool direct, bool undefined, ExcInfo &exc);
-    GlueTable *table_create(const StringBridge &path, GlueTableDesc &table_desc, unsigned long n_rows, const TableCreateMode mode, ExcInfo &exc);
+    GlueTableDesc *tabledesc_create(const StringBridge &type, const TableDescCreateMode mode, 
+                                    ExcInfo &exc);
+    GlueTableDesc *tabledesc_add_scalar_column(GlueTableDesc &table_desc, GlueDataType data_type, 
+                                               const StringBridge &col_name, const StringBridge 
+                                               &comment, bool direct, bool undefined, ExcInfo &exc);
+    GlueTableDesc *tabledesc_add_array_column(GlueTableDesc &table_desc, GlueDataType data_type, 
+                                              const StringBridge &col_name, const StringBridge &comment, 
+                                              bool direct, bool undefined, ExcInfo &exc);
+    GlueTableDesc *tabledesc_add_fixed_array_column(GlueTableDesc &table_desc, GlueDataType data_type, 
+                                                    const StringBridge &col_name, const StringBridge &comment, 
+                                                    const unsigned long n_dims, const unsigned long *dims, 
+                                                    bool direct, bool undefined, ExcInfo &exc);
+    GlueTable *table_create(const StringBridge &path, GlueTableDesc &table_desc, 
+                            unsigned long n_rows, const TableCreateMode mode, ExcInfo &exc);
     GlueTable *table_alloc_and_open(const StringBridge &path, const TableOpenMode mode, ExcInfo &exc);
     void table_close_and_free(GlueTable *table, ExcInfo &exc);
     unsigned long table_n_rows(const GlueTable &table);
@@ -141,6 +157,8 @@ extern "C" {
     unsigned long table_n_keywords(const GlueTable &table);
     int table_get_keyword_info(const GlueTable &table, KeywordInfoCallback callback,
                                void *ctxt, ExcInfo &exc);
+    int table_put_keyword(GlueTable &table, const StringBridge &kw_name, const GlueDataType data_type, 
+                          void *data, ExcInfo &exc);
     int table_copy_rows(const GlueTable &source, GlueTable &dest, ExcInfo &exc);
     int table_deep_copy_no_rows(const GlueTable &table, const StringBridge &dest_path, ExcInfo &exc);
     int table_get_column_info(const GlueTable &table, const StringBridge &col_name,
@@ -148,9 +166,13 @@ extern "C" {
                               int *is_scalar, int *is_fixed_shape, int *n_dim,
                               unsigned long dims[8], ExcInfo &exc);
     int table_remove_column(GlueTable &table, const StringBridge &col_name, ExcInfo &exc);
-    int table_add_scalar_column(GlueTable &table, GlueDataType data_type, const StringBridge &col_name, const StringBridge &comment, bool direct, bool undefined, ExcInfo &exc );
-    int table_add_array_column( GlueTable &table, GlueDataType data_type, const StringBridge &col_name, const StringBridge &comment, bool direct, bool undefined, ExcInfo &exc);
-    int table_add_fixed_array_column( GlueTable &table, GlueDataType data_type, const StringBridge &col_name, const StringBridge &comment, const unsigned long n_dims, const unsigned long *dims, bool direct, bool undefined, ExcInfo &exc);
+    int table_add_scalar_column(GlueTable &table, GlueDataType data_type, const StringBridge &col_name, 
+                                const StringBridge &comment, bool direct, bool undefined, ExcInfo &exc);
+    int table_add_array_column(GlueTable &table, GlueDataType data_type, const StringBridge &col_name, 
+                               const StringBridge &comment, bool direct, bool undefined, ExcInfo &exc);
+    int table_add_fixed_array_column(GlueTable &table, GlueDataType data_type, const StringBridge &col_name, 
+                                     const StringBridge &comment, const unsigned long n_dims, 
+                                     const unsigned long *dims, bool direct, bool undefined, ExcInfo &exc);
     int table_get_scalar_column_data(const GlueTable &table, const StringBridge &col_name,
                                      void *data, ExcInfo &exc);
     int table_get_scalar_column_data_string(const GlueTable &table, const StringBridge &col_name,

--- a/casatables/src/glue.rs
+++ b/casatables/src/glue.rs
@@ -265,6 +265,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn table_put_keyword(
+        table: *mut GlueTable,
+        kw_name: *const StringBridge,
+        data_type: GlueDataType,
+        data: *mut ::std::os::raw::c_void,
+        exc: *mut ExcInfo,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn table_copy_rows(
         source: *const GlueTable,
         dest: *mut GlueTable,


### PR DESCRIPTION
Addresses https://github.com/pkgw/rubbl/issues/164 

This is a Draft PR to get your feedback on my implementation. It has a test that's segfaulting at

```txt
#0  0x00007ffff7f19c08 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#1  0x0000555555600311 in casacore::String::String (this=0x7ffff002ce68) at /home/ubuntu/rubbl/target/debug/build/rubbl_casatables_impl-b90cb19125ea5ef7/out/include/casacore/casa/BasicSL/String.h:223
#2  0x00005555558a6c0c in casacore::TableAttr::TableAttr (this=0x7ffff002ce68, table=...) at casacore/tables/Tables/TableAttr.cc:43
#3  0x00005555558b6541 in casacore::TableKeyword::TableKeyword (this=0x7ffff002ce60, table=..., tableDescName=...) at casacore/tables/Tables/TableKeyword.cc:48
#4  0x00005555558bc489 in casacore::TableRecordRep::addField (this=0x7ffff0018b40, name=..., value=..., type=casacore::RecordInterface::Variable) at casacore/tables/Tables/TableRecordRep.cc:163
#5  0x00005555558b9b02 in casacore::TableRecord::defineTable (this=0x7ffff0002b70, id=..., value=..., type=casacore::RecordInterface::Variable) at casacore/tables/Tables/TableRecord.cc:297
#6  0x00005555556086c9 in table_put_keyword (table=..., kw_name=..., data_type=casacore::TpTable, data=0x7ffff00039e0, exc=...) at src/glue.cc:695
#7  0x00005555555e836a in rubbl_casatables::Table::put_table_keyword (self=0x7ffff7a47478, kw_name=..., table=...) at casatables/src/lib.rs:1011
#8  0x00005555555fe511 in rubbl_casatables::tests::table_put_table_keyword () at casatables/src/lib.rs:2114
#9  0x00005555555eecfa in rubbl_casatables::tests::table_put_table_keyword::{{closure}} () at casatables/src/lib.rs:2089
#10 0x00005555555fef8e in core::ops::function::FnOnce::call_once () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/ops/function.rs:227
#11 0x00005555558fc233 in core::ops::function::FnOnce::call_once () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/ops/function.rs:227
#12 test::__rust_begin_short_backtrace () at library/test/src/lib.rs:578
#13 0x00005555558face8 in <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/alloc/src/boxed.rs:1572
#14 <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panic.rs:347
#15 std::panicking::try::do_call () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:401
#16 std::panicking::try () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:365
#17 std::panic::catch_unwind () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panic.rs:434
#18 test::run_test_in_process () at library/test/src/lib.rs:601
#19 test::run_test::run_test_inner::{{closure}} () at library/test/src/lib.rs:493
#20 0x00005555558c947d in test::run_test::run_test_inner::{{closure}} () at library/test/src/lib.rs:520
#21 std::sys_common::backtrace::__rust_begin_short_backtrace () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/sys_common/backtrace.rs:125
#22 0x00005555558cdc58 in std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}} () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/thread/mod.rs:476
#23 <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panic.rs:347
#24 std::panicking::try::do_call () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:401
#25 std::panicking::try () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:365
#26 std::panic::catch_unwind () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panic.rs:434
#27 std::thread::Builder::spawn_unchecked::{{closure}} () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/thread/mod.rs:475
#28 core::ops::function::FnOnce::call_once{{vtable-shim}} () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/ops/function.rs:227
#29 0x0000555555a31727 in <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/alloc/src/boxed.rs:1572
#30 <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once () at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/alloc/src/boxed.rs:1572
#31 std::sys::unix::thread::Thread::new::thread_start () at library/std/src/sys/unix/thread.rs:74
#32 0x00007ffff7d9f609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#33 0x00007ffff7b71293 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

It's probably a simple fix but it's a friday arvo and I wanted to get this out to you before the weekend :) 

Thanks.