### PR TITLE
fix TpArrayString shape issue

### DIFF
--- a/casatables/src/lib.rs
+++ b/casatables/src/lib.rs
@@ -282,6 +282,11 @@ impl CasaDataType for Vec<String> {
         }
     }
 
+    fn casatables_put_shape(&self, shape_dest: &mut Vec<u64>) {
+        shape_dest.truncate(0);
+        shape_dest.push(self.len() as u64);
+    }
+
     fn casatables_stringvec_pass_through(s: Vec<String>) -> Self {
         s
     }


### PR DESCRIPTION
simply override `casatables_put_shape` in `impl CasaDataType for Vec<String>` to set the shape correctly

Partly addresses https://github.com/pkgw/rubbl/issues/173

I wanted to test this with something like 

```rust
    #[test]
    fn table_add_string_vector_column() {
        // tempdir is only necessary to avoid writing to disk each time this example is run
        let tmp_dir = tempdir().unwrap();
        let table_path = tmp_dir.path().join("test.ms");
        // First create a table description for our base table.
        // Use TDM_SCRATCH to avoid writing the .tabdsc to disk.
        let mut table_desc = TableDesc::new("", TableDescCreateMode::TDM_SCRATCH).unwrap();
        // Define the columns in your table description
        table_desc
            .add_array_column(
                GlueDataType::TpString,
                "APP_PARAMS",
                Some("Application parameters"),
                None,
                true,
                false,
            )
            .unwrap();
        table_desc.set_ndims("APP_PARAMS", 1).unwrap();
        // Create your new table with 1 rows
        let mut table = Table::new(&table_path, table_desc, 1, TableCreateMode::New).unwrap();
        // write to the first row in the uvw column
        let cell_value: Vec<String> = vec!["app params".to_string()];
        table.put_cell("APP_PARAMS", 0, &cell_value).unwrap();
        // This writes the table to disk and closes the file pointer.
        drop(table);

        let mut table = Table::open(&table_path, TableOpenMode::Read).unwrap();
        let aparams_tabledesc = table.get_col_desc("APP_PARAMS").unwrap();
        assert_eq!(aparams_tabledesc.data_type(), GlueDataType::TpString);
        assert!(aparams_tabledesc.is_fixed_shape());
        assert!(!aparams_tabledesc.is_scalar());
        
        let cell_value_read: Vec<String> = table.get_cell("APP_PARAMS", 0).unwrap();
        assert_eq!(cell_value_read, cell_value);
    }
```
but we need some way of creating an array column with a fixed number of dims, but no fixed shape, which isn't currently possible, so I'll open a ticket for that.