### PR TITLE
casatables: bump internal dependency on casatables_impl

### DIFF
--- a/casatables/Cargo.toml
+++ b/casatables/Cargo.toml
@@ -14,7 +14,7 @@ Interfacing to the CASA table format within the Rubbl framework.
 """
 
 [package.metadata.internal_dep_versions]
-rubbl_casatables_impl = "1d861e38cc1a40a6f0c984a58ae3dee54c27d127"
+rubbl_casatables_impl = "thiscommit:2021-11-04:9Lgzrtq"
 rubbl_core = "thiscommit:2020-12-15:EiT8sa0a"
 
 [dependencies]


### PR DESCRIPTION
The two packages need to agree about the casacore name munging, so we require the latest version.