### PR TITLE
[#180] add keyword record manipulation

### DIFF
--- a/casatables/src/glue.cc
+++ b/casatables/src/glue.cc
@@ -169,14 +169,13 @@ extern "C" {
     int
     tablerec_get_keyword_info(
         const GlueTableRecord &rec, 
-        KeywordReprCallback callback, 
+        KeywordInfoCallback callback, 
         void *ctxt, 
         ExcInfo &exc
     )
     {
         try {
             StringBridge name;
-            StringBridge repr;
             casacore::uInt n_kws = rec.nfields();
 
             for (casacore::uInt i = 0; i < n_kws; i++) {
@@ -186,21 +185,7 @@ extern "C" {
                 const casacore::String n = rec.name(i);
                 name.data = n.data();
                 name.n_bytes = n.length();
-
-                std::ostringstream os;
-                const casacore::ValueHolder vh = rec.asValueHolder(i);
-                if (rec.type(i) == casacore::TpRecord) {
-                    os << "{" << std::endl;
-                }
-                os << vh;
-                if (rec.type(i) == casacore::TpRecord) {
-                    os << "}";
-                }
-
-                const casacore::String r(os.str());
-                repr.data = r.data();
-                repr.n_bytes = r.length();
-                callback(&name, rec.type(i), &repr, ctxt);
+                callback(&name, rec.type(i),  ctxt);
             }
         } catch (...) {
             handle_exception(exc);
@@ -1136,7 +1121,7 @@ extern "C" {
     int
     table_get_keyword_info(
         const GlueTable &table, 
-        KeywordReprCallback callback, 
+        KeywordInfoCallback callback, 
         void *ctxt, 
         ExcInfo &exc
     )
@@ -1153,7 +1138,7 @@ extern "C" {
     table_get_column_keyword_info(
         const GlueTable &table, 
         const StringBridge &col_name, 
-        KeywordReprCallback callback,
+        KeywordInfoCallback callback,
         void *ctxt, 
         ExcInfo &exc
     )

--- a/casatables/src/glue.cc
+++ b/casatables/src/glue.cc
@@ -939,6 +939,24 @@ extern "C" {
     }
 
     int
+    table_get_file_name(
+        const GlueTable &table,
+        StringBridgeCallback callback, 
+        void *ctxt,
+        ExcInfo &exc
+    )
+    {
+        try {
+            casacore::String file_name = table.tableName();
+            unbridge_string(file_name, callback, ctxt);
+        } catch (...) {
+            handle_exception(exc);
+            return 1;
+        }
+        return 0;
+    }
+
+    int
     table_get_column_names(const GlueTable &table, StringBridgeCallback callback,
                            void *ctxt, ExcInfo &exc)
     {

--- a/casatables/src/glue.h
+++ b/casatables/src/glue.h
@@ -88,6 +88,7 @@ typedef void (*StringBridgeCallback)(const StringBridge *name, void *ctxt);
 // A more specific callback type for table_get_keyword_info, in which there is
 // additional information we'd like to to transfer.
 typedef void (*KeywordInfoCallback)(const StringBridge *name, GlueDataType dtype, void *ctxt);
+typedef void (*KeywordReprCallback)(const StringBridge *name, GlueDataType dtype, const StringBridge *repr, void *ctxt);
 
 typedef enum TableOpenMode
 {
@@ -146,6 +147,13 @@ extern "C"
         KeywordInfoCallback callback,
         void *ctxt,
         ExcInfo &exc);
+    int
+    tablerec_get_keyword_repr(
+        const GlueTableRecord &rec, 
+        KeywordReprCallback callback, 
+        void *ctxt, 
+        ExcInfo &exc
+    );
     int tablerec_get_field_info(
         const GlueTableRecord &rec,
         const StringBridge &col_name,

--- a/casatables/src/glue.h
+++ b/casatables/src/glue.h
@@ -261,6 +261,7 @@ extern "C"
     void table_close_and_free(GlueTable *table, ExcInfo &exc);
     unsigned long table_n_rows(const GlueTable &table);
     unsigned long table_n_columns(const GlueTable &table);
+    int table_get_file_name(const GlueTable &table, StringBridgeCallback callback, void *ctxt, ExcInfo &exc);
     int table_get_column_names(const GlueTable &table, StringBridgeCallback callback,
                                void *ctxt, ExcInfo &exc);
     unsigned long table_n_keywords(const GlueTable &table);

--- a/casatables/src/glue.h
+++ b/casatables/src/glue.h
@@ -54,6 +54,8 @@ typedef enum GlueDataType
 typedef struct GlueTable GlueTable;
 typedef struct GlueTableRow GlueTableRow;
 typedef struct GlueTableDesc GlueTableDesc;
+typedef struct GlueTableRecord GlueTableRecord; 
+
 #endif
 
 // OMG, strings. First of all: casacore::String is a subclass of std::string,
@@ -86,6 +88,8 @@ typedef void (*StringBridgeCallback)(const StringBridge *name, void *ctxt);
 // A more specific callback type for table_get_keyword_info, in which there is
 // additional information we'd like to to transfer.
 typedef void (*KeywordInfoCallback)(const StringBridge *name, GlueDataType dtype, void *ctxt);
+typedef void (*KeywordReprCallback)(const StringBridge *name, GlueDataType dtype, const StringBridge *repr, void *ctxt);
+typedef void (*KeywordRecordCallback)(const StringBridge *name, GlueDataType dtype, void *rec, void *ctxt);
 
 typedef enum TableOpenMode
 {
@@ -134,22 +138,118 @@ extern "C"
 {
     int data_type_get_element_size(const GlueDataType ty);
 
-    GlueTableDesc *tabledesc_create(const StringBridge &type, const TableDescCreateMode mode, 
-                                    ExcInfo &exc);
-    GlueTableDesc *tabledesc_add_scalar_column(GlueTableDesc &table_desc, GlueDataType data_type, 
-                                               const StringBridge &col_name, const StringBridge 
-                                               &comment, bool direct, bool undefined, ExcInfo &exc);
-    GlueTableDesc *tabledesc_add_array_column(GlueTableDesc &table_desc, GlueDataType data_type, 
-                                              const StringBridge &col_name, const StringBridge &comment, 
-                                              bool direct, bool undefined, ExcInfo &exc);
-    GlueTableDesc *tabledesc_add_fixed_array_column(GlueTableDesc &table_desc, GlueDataType data_type, 
-                                                    const StringBridge &col_name, const StringBridge &comment, 
-                                                    const unsigned long n_dims, const unsigned long *dims, 
-                                                    bool direct, bool undefined, ExcInfo &exc);
-    GlueTableDesc *tabledesc_set_ndims(GlueTableDesc &table_desc, const StringBridge &col_name, 
-                                                    const unsigned long n_dims,
-                                                    ExcInfo &exc);
-    GlueTable *table_create(const StringBridge &path, GlueTableDesc &table_desc, 
+    // Table Records
+
+    GlueTableRecord *tablerec_create(ExcInfo &exc);
+    GlueTableRecord *tablerec_copy(const GlueTableRecord &other, ExcInfo &exc);
+    bool tablerec_eq(const GlueTableRecord &rec, const GlueTableRecord &other);
+    int tablerec_get_keyword_info(
+        const GlueTableRecord &rec,
+        KeywordReprCallback callback,
+        void *ctxt,
+        ExcInfo &exc);
+    int tablerec_get_field_info(
+        const GlueTableRecord &rec,
+        const StringBridge &col_name,
+        GlueDataType *data_type,
+        int *n_dim,
+        unsigned long dims[8],
+        ExcInfo &exc);
+    int tablerec_get_field(
+        const GlueTableRecord &rec,
+        const StringBridge &field_name,
+        void *data,
+        ExcInfo &exc);
+    int tablerec_get_field_string(
+        const GlueTableRecord &rec,
+        const StringBridge &col_name,
+        StringBridgeCallback callback,
+        void *ctxt,
+        ExcInfo &exc);
+    int tablerec_get_field_string_array(
+        const GlueTableRecord &rec,
+        const StringBridge &col_name,
+        StringBridgeCallback callback,
+        void *ctxt,
+        ExcInfo &exc);
+    int tablerec_get_field_subrecord(
+        const GlueTableRecord &rec,
+        const StringBridge &col_name,
+        GlueTableRecord &sub_rec,
+        ExcInfo &exc);
+    int tablerec_put_field(
+        GlueTableRecord &rec,
+        const StringBridge &field_name,
+        const GlueDataType data_type,
+        const unsigned long n_dims,
+        const unsigned long *dims,
+        void *data,
+        ExcInfo &exc);
+    int tablerec_free(GlueTableRecord *rec, ExcInfo &exc);
+
+    // Table Description
+
+    GlueTableDesc *tabledesc_create(
+        const StringBridge &type,
+        const TableDescCreateMode mode,
+        ExcInfo &exc);
+    int tabledesc_add_scalar_column(
+        GlueTableDesc &table_desc,
+        GlueDataType data_type,
+        const StringBridge &col_name,
+        const StringBridge &comment,
+        bool direct,
+        bool undefined,
+        ExcInfo &exc);
+    int tabledesc_add_array_column(
+        GlueTableDesc &table_desc,
+        GlueDataType data_type,
+        const StringBridge &col_name,
+        const StringBridge &comment,
+        bool direct,
+        bool undefined,
+        ExcInfo &exc);
+    int tabledesc_add_fixed_array_column(
+        GlueTableDesc &table_desc,
+        GlueDataType data_type,
+        const StringBridge &col_name,
+        const StringBridge &comment,
+        const unsigned long n_dims,
+        const unsigned long *dims,
+        bool direct,
+        bool undefined,
+        ExcInfo &exc);
+    int tabledesc_set_ndims(
+        GlueTableDesc &table_desc,
+        const StringBridge &col_name,
+        const unsigned long n_dims,
+        ExcInfo &exc);
+    const GlueTableRecord * tabledesc_get_keywords(GlueTableDesc &table_desc, ExcInfo &exc);
+    const GlueTableRecord * tabledesc_get_column_keywords(
+        GlueTableDesc &table_desc, const StringBridge &col_name, ExcInfo &exc);
+    int tabledesc_put_keyword(
+        GlueTableDesc &table_desc,
+        const StringBridge &kw_name,
+        const GlueDataType data_type,
+        const unsigned long n_dims,
+        const unsigned long *dims,
+        void *data,
+        ExcInfo &exc
+    );
+    int tabledesc_put_column_keyword(
+        GlueTableDesc &table_desc,
+        const StringBridge &col_name,
+        const StringBridge &kw_name,
+        const GlueDataType data_type,
+        const unsigned long n_dims,
+        const unsigned long *dims,
+        void *data,
+        ExcInfo &exc
+    );
+    
+    // Table
+
+    GlueTable *table_create(const StringBridge &path, GlueTableDesc &table_desc,
                             unsigned long n_rows, const TableCreateMode mode, ExcInfo &exc);
     GlueTable *table_alloc_and_open(const StringBridge &path, const TableOpenMode mode, ExcInfo &exc);
     void table_close_and_free(GlueTable *table, ExcInfo &exc);
@@ -158,10 +258,30 @@ extern "C"
     int table_get_column_names(const GlueTable &table, StringBridgeCallback callback,
                                void *ctxt, ExcInfo &exc);
     unsigned long table_n_keywords(const GlueTable &table);
-    int table_get_keyword_info(const GlueTable &table, KeywordInfoCallback callback,
+    int table_get_keyword_info(const GlueTable &table, KeywordReprCallback callback,
                                void *ctxt, ExcInfo &exc);
-    int table_put_keyword(GlueTable &table, const StringBridge &kw_name, const GlueDataType data_type, 
-                          void *data, ExcInfo &exc);
+    int table_get_column_keyword_info(const GlueTable &table, const StringBridge &col_name,
+                                      KeywordReprCallback callback, void *ctxt, ExcInfo &exc);
+    const GlueTableRecord *table_get_keywords(GlueTable &table, ExcInfo &exc);
+    const GlueTableRecord *table_get_column_keywords(
+        GlueTable &table,
+        const StringBridge &col_name,
+        ExcInfo &exc);
+    int table_put_keyword(
+        GlueTable &table,
+        const StringBridge &kw_name,
+        const GlueDataType data_type,
+        const unsigned long n_dims,
+        const unsigned long *dims,
+        void *data,
+        ExcInfo &exc);
+    int table_put_column_keyword(
+        GlueTable &table,
+        const StringBridge &col_name,
+        const StringBridge &kw_name,
+        const GlueDataType data_type,
+        const unsigned long n_dims, const unsigned long *dims, void *data,
+        ExcInfo &exc);
     int table_copy_rows(const GlueTable &source, GlueTable &dest, ExcInfo &exc);
     int table_deep_copy_no_rows(const GlueTable &table, const StringBridge &dest_path, ExcInfo &exc);
     int table_get_column_info(const GlueTable &table, const StringBridge &col_name,
@@ -169,12 +289,12 @@ extern "C"
                               int *is_scalar, int *is_fixed_shape, int *n_dim,
                               unsigned long dims[8], ExcInfo &exc);
     int table_remove_column(GlueTable &table, const StringBridge &col_name, ExcInfo &exc);
-    int table_add_scalar_column(GlueTable &table, GlueDataType data_type, const StringBridge &col_name, 
+    int table_add_scalar_column(GlueTable &table, GlueDataType data_type, const StringBridge &col_name,
                                 const StringBridge &comment, bool direct, bool undefined, ExcInfo &exc);
-    int table_add_array_column(GlueTable &table, GlueDataType data_type, const StringBridge &col_name, 
+    int table_add_array_column(GlueTable &table, GlueDataType data_type, const StringBridge &col_name,
                                const StringBridge &comment, bool direct, bool undefined, ExcInfo &exc);
-    int table_add_fixed_array_column(GlueTable &table, GlueDataType data_type, const StringBridge &col_name, 
-                                     const StringBridge &comment, const unsigned long n_dims, 
+    int table_add_fixed_array_column(GlueTable &table, GlueDataType data_type, const StringBridge &col_name,
+                                     const StringBridge &comment, const unsigned long n_dims,
                                      const unsigned long *dims, bool direct, bool undefined, ExcInfo &exc);
     int table_get_scalar_column_data(const GlueTable &table, const StringBridge &col_name,
                                      void *data, ExcInfo &exc);

--- a/casatables/src/glue.h
+++ b/casatables/src/glue.h
@@ -88,8 +88,6 @@ typedef void (*StringBridgeCallback)(const StringBridge *name, void *ctxt);
 // A more specific callback type for table_get_keyword_info, in which there is
 // additional information we'd like to to transfer.
 typedef void (*KeywordInfoCallback)(const StringBridge *name, GlueDataType dtype, void *ctxt);
-typedef void (*KeywordReprCallback)(const StringBridge *name, GlueDataType dtype, const StringBridge *repr, void *ctxt);
-typedef void (*KeywordRecordCallback)(const StringBridge *name, GlueDataType dtype, void *rec, void *ctxt);
 
 typedef enum TableOpenMode
 {
@@ -145,7 +143,7 @@ extern "C"
     bool tablerec_eq(const GlueTableRecord &rec, const GlueTableRecord &other);
     int tablerec_get_keyword_info(
         const GlueTableRecord &rec,
-        KeywordReprCallback callback,
+        KeywordInfoCallback callback,
         void *ctxt,
         ExcInfo &exc);
     int tablerec_get_field_info(
@@ -258,10 +256,10 @@ extern "C"
     int table_get_column_names(const GlueTable &table, StringBridgeCallback callback,
                                void *ctxt, ExcInfo &exc);
     unsigned long table_n_keywords(const GlueTable &table);
-    int table_get_keyword_info(const GlueTable &table, KeywordReprCallback callback,
+    int table_get_keyword_info(const GlueTable &table, KeywordInfoCallback callback,
                                void *ctxt, ExcInfo &exc);
     int table_get_column_keyword_info(const GlueTable &table, const StringBridge &col_name,
-                                      KeywordReprCallback callback, void *ctxt, ExcInfo &exc);
+                                      KeywordInfoCallback callback, void *ctxt, ExcInfo &exc);
     const GlueTableRecord *table_get_keywords(GlueTable &table, ExcInfo &exc);
     const GlueTableRecord *table_get_column_keywords(
         GlueTable &table,

--- a/casatables/src/glue.rs
+++ b/casatables/src/glue.rs
@@ -163,6 +163,14 @@ pub type KeywordInfoCallback = ::std::option::Option<
         ctxt: *mut ::std::os::raw::c_void,
     ),
 >;
+pub type KeywordReprCallback = ::std::option::Option<
+    unsafe extern "C" fn(
+        name: *const StringBridge,
+        dtype: GlueDataType,
+        repr: *const StringBridge,
+        ctxt: *mut ::std::os::raw::c_void,
+    ),
+>;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum TableOpenMode {
@@ -201,6 +209,14 @@ extern "C" {
     pub fn tablerec_get_keyword_info(
         rec: *const GlueTableRecord,
         callback: KeywordInfoCallback,
+        ctxt: *mut ::std::os::raw::c_void,
+        exc: *mut ExcInfo,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn tablerec_get_keyword_repr(
+        rec: *const GlueTableRecord,
+        callback: KeywordReprCallback,
         ctxt: *mut ::std::os::raw::c_void,
         exc: *mut ExcInfo,
     ) -> ::std::os::raw::c_int;

--- a/casatables/src/glue.rs
+++ b/casatables/src/glue.rs
@@ -391,6 +391,14 @@ extern "C" {
     pub fn table_n_columns(table: *const GlueTable) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
+    pub fn table_get_file_name(
+        table: *const GlueTable,
+        callback: StringBridgeCallback,
+        ctxt: *mut ::std::os::raw::c_void,
+        exc: *mut ExcInfo,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn table_get_column_names(
         table: *const GlueTable,
         callback: StringBridgeCallback,

--- a/casatables/src/glue.rs
+++ b/casatables/src/glue.rs
@@ -163,22 +163,6 @@ pub type KeywordInfoCallback = ::std::option::Option<
         ctxt: *mut ::std::os::raw::c_void,
     ),
 >;
-pub type KeywordReprCallback = ::std::option::Option<
-    unsafe extern "C" fn(
-        name: *const StringBridge,
-        dtype: GlueDataType,
-        repr: *const StringBridge,
-        ctxt: *mut ::std::os::raw::c_void,
-    ),
->;
-pub type KeywordRecordCallback = ::std::option::Option<
-    unsafe extern "C" fn(
-        name: *const StringBridge,
-        dtype: GlueDataType,
-        rec: *mut ::std::os::raw::c_void,
-        ctxt: *mut ::std::os::raw::c_void,
-    ),
->;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum TableOpenMode {
@@ -216,7 +200,7 @@ extern "C" {
 extern "C" {
     pub fn tablerec_get_keyword_info(
         rec: *const GlueTableRecord,
-        callback: KeywordReprCallback,
+        callback: KeywordInfoCallback,
         ctxt: *mut ::std::os::raw::c_void,
         exc: *mut ExcInfo,
     ) -> ::std::os::raw::c_int;
@@ -404,7 +388,7 @@ extern "C" {
 extern "C" {
     pub fn table_get_keyword_info(
         table: *const GlueTable,
-        callback: KeywordReprCallback,
+        callback: KeywordInfoCallback,
         ctxt: *mut ::std::os::raw::c_void,
         exc: *mut ExcInfo,
     ) -> ::std::os::raw::c_int;
@@ -413,7 +397,7 @@ extern "C" {
     pub fn table_get_column_keyword_info(
         table: *const GlueTable,
         col_name: *const StringBridge,
-        callback: KeywordReprCallback,
+        callback: KeywordInfoCallback,
         ctxt: *mut ::std::os::raw::c_void,
         exc: *mut ExcInfo,
     ) -> ::std::os::raw::c_int;

--- a/casatables/src/glue.rs
+++ b/casatables/src/glue.rs
@@ -68,6 +68,16 @@ impl Clone for GlueTableDesc {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
+pub struct GlueTableRecord {
+    _unused: [u8; 0],
+}
+impl Clone for GlueTableRecord {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy)]
 pub struct StringBridge {
     pub data: *const ::std::os::raw::c_void,
     pub n_bytes: ::std::os::raw::c_ulong,
@@ -153,6 +163,22 @@ pub type KeywordInfoCallback = ::std::option::Option<
         ctxt: *mut ::std::os::raw::c_void,
     ),
 >;
+pub type KeywordReprCallback = ::std::option::Option<
+    unsafe extern "C" fn(
+        name: *const StringBridge,
+        dtype: GlueDataType,
+        repr: *const StringBridge,
+        ctxt: *mut ::std::os::raw::c_void,
+    ),
+>;
+pub type KeywordRecordCallback = ::std::option::Option<
+    unsafe extern "C" fn(
+        name: *const StringBridge,
+        dtype: GlueDataType,
+        rec: *mut ::std::os::raw::c_void,
+        ctxt: *mut ::std::os::raw::c_void,
+    ),
+>;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum TableOpenMode {
@@ -179,6 +205,81 @@ extern "C" {
     pub fn data_type_get_element_size(ty: GlueDataType) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn tablerec_create(exc: *mut ExcInfo) -> *mut GlueTableRecord;
+}
+extern "C" {
+    pub fn tablerec_copy(other: *const GlueTableRecord, exc: *mut ExcInfo) -> *mut GlueTableRecord;
+}
+extern "C" {
+    pub fn tablerec_eq(rec: *const GlueTableRecord, other: *const GlueTableRecord) -> bool;
+}
+extern "C" {
+    pub fn tablerec_get_keyword_info(
+        rec: *const GlueTableRecord,
+        callback: KeywordReprCallback,
+        ctxt: *mut ::std::os::raw::c_void,
+        exc: *mut ExcInfo,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn tablerec_get_field_info(
+        rec: *const GlueTableRecord,
+        col_name: *const StringBridge,
+        data_type: *mut GlueDataType,
+        n_dim: *mut ::std::os::raw::c_int,
+        dims: *mut ::std::os::raw::c_ulong,
+        exc: *mut ExcInfo,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn tablerec_get_field(
+        rec: *const GlueTableRecord,
+        field_name: *const StringBridge,
+        data: *mut ::std::os::raw::c_void,
+        exc: *mut ExcInfo,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn tablerec_get_field_string(
+        rec: *const GlueTableRecord,
+        col_name: *const StringBridge,
+        callback: StringBridgeCallback,
+        ctxt: *mut ::std::os::raw::c_void,
+        exc: *mut ExcInfo,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn tablerec_get_field_string_array(
+        rec: *const GlueTableRecord,
+        col_name: *const StringBridge,
+        callback: StringBridgeCallback,
+        ctxt: *mut ::std::os::raw::c_void,
+        exc: *mut ExcInfo,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn tablerec_get_field_subrecord(
+        rec: *const GlueTableRecord,
+        col_name: *const StringBridge,
+        sub_rec: *mut GlueTableRecord,
+        exc: *mut ExcInfo,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn tablerec_put_field(
+        rec: *mut GlueTableRecord,
+        field_name: *const StringBridge,
+        data_type: GlueDataType,
+        n_dims: ::std::os::raw::c_ulong,
+        dims: *const ::std::os::raw::c_ulong,
+        data: *mut ::std::os::raw::c_void,
+        exc: *mut ExcInfo,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn tablerec_free(rec: *mut GlueTableRecord, exc: *mut ExcInfo) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn tabledesc_create(
         type_: *const StringBridge,
         mode: TableDescCreateMode,
@@ -194,7 +295,7 @@ extern "C" {
         direct: bool,
         undefined: bool,
         exc: *mut ExcInfo,
-    ) -> *mut GlueTableDesc;
+    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn tabledesc_add_array_column(
@@ -205,7 +306,7 @@ extern "C" {
         direct: bool,
         undefined: bool,
         exc: *mut ExcInfo,
-    ) -> *mut GlueTableDesc;
+    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn tabledesc_add_fixed_array_column(
@@ -218,7 +319,7 @@ extern "C" {
         direct: bool,
         undefined: bool,
         exc: *mut ExcInfo,
-    ) -> *mut GlueTableDesc;
+    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn tabledesc_set_ndims(
@@ -226,7 +327,43 @@ extern "C" {
         col_name: *const StringBridge,
         n_dims: ::std::os::raw::c_ulong,
         exc: *mut ExcInfo,
-    ) -> *mut GlueTableDesc;
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn tabledesc_get_keywords(
+        table_desc: *mut GlueTableDesc,
+        exc: *mut ExcInfo,
+    ) -> *const GlueTableRecord;
+}
+extern "C" {
+    pub fn tabledesc_get_column_keywords(
+        table_desc: *mut GlueTableDesc,
+        col_name: *const StringBridge,
+        exc: *mut ExcInfo,
+    ) -> *const GlueTableRecord;
+}
+extern "C" {
+    pub fn tabledesc_put_keyword(
+        table_desc: *mut GlueTableDesc,
+        kw_name: *const StringBridge,
+        data_type: GlueDataType,
+        n_dims: ::std::os::raw::c_ulong,
+        dims: *const ::std::os::raw::c_ulong,
+        data: *mut ::std::os::raw::c_void,
+        exc: *mut ExcInfo,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn tabledesc_put_column_keyword(
+        table_desc: *mut GlueTableDesc,
+        col_name: *const StringBridge,
+        kw_name: *const StringBridge,
+        data_type: GlueDataType,
+        n_dims: ::std::os::raw::c_ulong,
+        dims: *const ::std::os::raw::c_ulong,
+        data: *mut ::std::os::raw::c_void,
+        exc: *mut ExcInfo,
+    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn table_create(
@@ -267,16 +404,49 @@ extern "C" {
 extern "C" {
     pub fn table_get_keyword_info(
         table: *const GlueTable,
-        callback: KeywordInfoCallback,
+        callback: KeywordReprCallback,
         ctxt: *mut ::std::os::raw::c_void,
         exc: *mut ExcInfo,
     ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn table_get_column_keyword_info(
+        table: *const GlueTable,
+        col_name: *const StringBridge,
+        callback: KeywordReprCallback,
+        ctxt: *mut ::std::os::raw::c_void,
+        exc: *mut ExcInfo,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn table_get_keywords(table: *mut GlueTable, exc: *mut ExcInfo) -> *const GlueTableRecord;
+}
+extern "C" {
+    pub fn table_get_column_keywords(
+        table: *mut GlueTable,
+        col_name: *const StringBridge,
+        exc: *mut ExcInfo,
+    ) -> *const GlueTableRecord;
 }
 extern "C" {
     pub fn table_put_keyword(
         table: *mut GlueTable,
         kw_name: *const StringBridge,
         data_type: GlueDataType,
+        n_dims: ::std::os::raw::c_ulong,
+        dims: *const ::std::os::raw::c_ulong,
+        data: *mut ::std::os::raw::c_void,
+        exc: *mut ExcInfo,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn table_put_column_keyword(
+        table: *mut GlueTable,
+        col_name: *const StringBridge,
+        kw_name: *const StringBridge,
+        data_type: GlueDataType,
+        n_dims: ::std::os::raw::c_ulong,
+        dims: *const ::std::os::raw::c_ulong,
         data: *mut ::std::os::raw::c_void,
         exc: *mut ExcInfo,
     ) -> ::std::os::raw::c_int;

--- a/casatables/src/lib.rs
+++ b/casatables/src/lib.rs
@@ -2209,6 +2209,13 @@ impl Drop for TableRow {
     }
 }
 
+/// FIXME: currently, to avoid potential double-frees, TableRecords are only created standalone, or 
+/// as copies of TableRecords owned by something else.
+/// 
+/// Ideally, there would be a lot of utility in having rewritable TableRecords, however this would 
+/// require keeping track of whether a TableRecord is owned, and not freeing owned TableRecords.
+/// 
+/// Further discussion here: https://github.com/pkgw/rubbl/pull/181#issuecomment-968493738
 #[derive(Clone)]
 pub struct TableRecord {
     handle: *mut glue::GlueTableRecord,
@@ -2487,6 +2494,7 @@ impl CasaDataType for TableRecord {
 }
 
 impl Drop for TableRecord {
+    /// Free the casacore::TableRecord handle
     fn drop(&mut self) {
         // TODO: we want to free standalone tablerecords, but not those which
         // are associated with a table, because they are freed automatically

--- a/casatables/src/lib.rs
+++ b/casatables/src/lib.rs
@@ -1273,7 +1273,7 @@ impl Table {
         let mut result = Vec::new();
 
         let rv = unsafe {
-            invoke_table_get_column_keyword_info(self.handle, &ccol_name, &mut self.exc_info, |name, dtype| {
+            invoke_table_get_column_keyword_info(self.handle, &ccol_name, &mut self.exc_info, |name, _dtype| {
                 result.push(name);
             })
         };

--- a/casatables/src/lib.rs
+++ b/casatables/src/lib.rs
@@ -10,7 +10,6 @@ use std::fmt;
 use std::path::Path;
 
 mod glue;
-
 pub use glue::{GlueDataType, TableDescCreateMode};
 
 // Exceptions
@@ -124,6 +123,18 @@ pub trait CasaDataType: Clone + PartialEq + Sized {
     /// A hack that lets us properly special-case string vectors
     #[doc(hidden)]
     fn casatables_stringvec_pass_through_out(_s: &Self) -> Vec<glue::StringBridge> {
+        unreachable!();
+    }
+
+    /// A hack that lets us properly special-case table records.
+    #[doc(hidden)]
+    fn casatables_tablerec_pass_through(_r: TableRecord) -> Self {
+        unreachable!();
+    }
+
+    /// A hack that lets us properly special-case table records
+    #[doc(hidden)]
+    fn casatables_tablerec_pass_through_out(_r: &Self) -> TableRecord {
         unreachable!();
     }
 
@@ -406,6 +417,18 @@ unsafe extern "C" fn casatables_keyword_info_cb<F>(
     f((&*name).to_rust(), dtype)
 }
 
+unsafe extern "C" fn casatables_keyword_repr_cb<F>(
+    name: *const glue::StringBridge,
+    dtype: glue::GlueDataType,
+    repr: *const glue::StringBridge,
+    ctxt: *mut std::os::raw::c_void,
+) where
+    F: FnMut(String, glue::GlueDataType, String),
+{
+    let f: &mut F = &mut *(ctxt as *mut F);
+    f((&*name).to_rust(), dtype, (&*repr).to_rust())
+}
+
 // The next part: wrappers that allow us to invoke the various callback-having
 // functions with Rust closures. The main point to having these functions is
 // basically to be able to assign a name to the function type `F`.
@@ -432,11 +455,29 @@ unsafe fn invoke_table_get_keyword_info<F>(
     mut f: F,
 ) -> std::os::raw::c_int
 where
-    F: FnMut(String, glue::GlueDataType),
+    F: FnMut(String, glue::GlueDataType, String),
 {
     glue::table_get_keyword_info(
         handle,
-        Some(casatables_keyword_info_cb::<F>),
+        Some(casatables_keyword_repr_cb::<F>),
+        &mut f as *mut _ as *mut std::os::raw::c_void,
+        exc_info,
+    )
+}
+
+unsafe fn invoke_table_get_column_keyword_info<F>(
+    handle: *mut glue::GlueTable,
+    ccol_name: &glue::StringBridge,
+    exc_info: &mut glue::ExcInfo,
+    mut f: F,
+) -> std::os::raw::c_int
+where
+    F: FnMut(String, glue::GlueDataType, String),
+{
+    glue::table_get_column_keyword_info(
+        handle,
+        ccol_name,
+        Some(casatables_keyword_repr_cb::<F>),
         &mut f as *mut _ as *mut std::os::raw::c_void,
         exc_info,
     )
@@ -500,6 +541,58 @@ where
     )
 }
 
+unsafe fn invoke_tablerec_get_keyword_info<F>(
+    handle: *mut glue::GlueTableRecord,
+    exc_info: &mut glue::ExcInfo,
+    mut f: F,
+) -> std::os::raw::c_int
+where
+    F: FnMut(String, glue::GlueDataType, String),
+{
+    glue::tablerec_get_keyword_info(
+        handle,
+        Some(casatables_keyword_repr_cb::<F>),
+        &mut f as *mut _ as *mut std::os::raw::c_void,
+        exc_info,
+    )
+}
+
+unsafe fn invoke_tablerec_get_field_string<F>(
+    handle: *mut glue::GlueTableRecord,
+    ccol_name: &glue::StringBridge,
+    exc_info: &mut glue::ExcInfo,
+    mut f: F,
+) -> std::os::raw::c_int
+where
+    F: FnMut(String),
+{
+    glue::tablerec_get_field_string(
+        handle,
+        ccol_name,
+        Some(casatables_string_bridge_cb::<F>),
+        &mut f as *mut _ as *mut std::os::raw::c_void,
+        exc_info,
+    )
+}
+
+unsafe fn invoke_tablerec_get_field_string_array<F>(
+    handle: *mut glue::GlueTableRecord,
+    ccol_name: &glue::StringBridge,
+    exc_info: &mut glue::ExcInfo,
+    mut f: F,
+) -> std::os::raw::c_int
+where
+    F: FnMut(String),
+{
+    glue::tablerec_get_field_string_array(
+        handle,
+        ccol_name,
+        Some(casatables_string_bridge_cb::<F>),
+        &mut f as *mut _ as *mut std::os::raw::c_void,
+        exc_info,
+    )
+}
+
 unsafe fn invoke_table_row_get_cell_string<F>(
     handle: *mut glue::GlueTableRow,
     ccol_name: &glue::StringBridge,
@@ -554,7 +647,7 @@ where
 /// "fixed complex vector"
 ///
 /// ```rust
-/// use rubbl_casatables::{GlueDataType, TableDesc, TableDescCreateMode};
+/// use rubbl_casatables::{GlueDataType, TableDescCreateMode, TableDesc};
 ///
 /// let mut table_desc = TableDesc::new("TYPE", TableDescCreateMode::TDM_SCRATCH).unwrap();
 /// table_desc
@@ -610,7 +703,7 @@ impl TableDesc {
             ""
         };
         let ccomment = glue::StringBridge::from_rust(comment);
-        let new_handle = unsafe {
+        let rv = unsafe {
             glue::tabledesc_add_scalar_column(
                 self.handle,
                 data_type,
@@ -622,7 +715,7 @@ impl TableDesc {
             )
         };
 
-        if new_handle.is_null() {
+        if rv != 0 {
             return self.exc_info.as_err();
         }
 
@@ -649,7 +742,7 @@ impl TableDesc {
             ""
         };
         let ccomment = glue::StringBridge::from_rust(comment);
-        let new_handle = unsafe {
+        let rv = unsafe {
             if let Some(dims_) = dims {
                 glue::tabledesc_add_fixed_array_column(
                     self.handle,
@@ -675,7 +768,7 @@ impl TableDesc {
             }
         };
 
-        if new_handle.is_null() {
+        if rv != 0 {
             return self.exc_info.as_err();
         }
 
@@ -683,23 +776,114 @@ impl TableDesc {
     }
 
     /// Set the number of dimensions of a column
-    pub fn set_ndims(
+    pub fn set_ndims(&mut self, col_name: &str, ndims: u64) -> Result<(), Error> {
+        let cname = glue::StringBridge::from_rust(col_name);
+        let rv =
+            unsafe { glue::tabledesc_set_ndims(self.handle, &cname, ndims, &mut self.exc_info) };
+
+        if rv != 0 {
+            return self.exc_info.as_err();
+        }
+
+        Ok(())
+    }
+
+    /// Return a copy of the keyword TableRecord
+    pub fn get_keyword_record(&mut self) -> Result<TableRecord, CasacoreError> {
+        let handle = unsafe { glue::tabledesc_get_keywords(self.handle, &mut self.exc_info) };
+
+        if handle.is_null() {
+            return self.exc_info.as_err();
+        }
+
+        TableRecord::copy_handle(unsafe { &*handle })
+    }
+
+    /// Return a copy of the keyword TableRecord for a given column.
+    pub fn get_column_keyword_record(
         &mut self,
         col_name: &str,
-        ndims: u64,
-    ) -> Result<(), Error> {
-        let cname = glue::StringBridge::from_rust(col_name);
-        let new_handle = unsafe {
-            glue::tabledesc_set_ndims(
-                self.handle,
-                &cname,
-                ndims,
-                &mut self.exc_info,
-            )
+    ) -> Result<TableRecord, CasacoreError> {
+        let ccol_name = glue::StringBridge::from_rust(col_name);
+        let handle = unsafe {
+            glue::tabledesc_get_column_keywords(self.handle, &ccol_name, &mut self.exc_info)
         };
 
-        if new_handle.is_null() {
+        if handle.is_null() {
             return self.exc_info.as_err();
+        }
+
+        TableRecord::copy_handle(unsafe { &*handle })
+    }
+
+    pub fn put_column_keyword<T: CasaDataType>(
+        &mut self,
+        col_name: &str,
+        kw_name: &str,
+        value: &T,
+    ) -> Result<(), CasacoreError> {
+        let ccol_name = glue::StringBridge::from_rust(col_name);
+        let ckw_name = glue::StringBridge::from_rust(kw_name);
+        let mut shape = Vec::new();
+
+        value.casatables_put_shape(&mut shape);
+
+        if T::DATA_TYPE == glue::GlueDataType::TpString {
+            let as_string = T::casatables_string_pass_through_out(value);
+            let glue_string = glue::StringBridge::from_rust(&as_string);
+
+            let rv = unsafe {
+                glue::tabledesc_put_column_keyword(
+                    self.handle,
+                    &ccol_name,
+                    &ckw_name,
+                    T::DATA_TYPE,
+                    shape.len() as u64,
+                    shape.as_ptr(),
+                    &glue_string as *const glue::StringBridge as _,
+                    &mut self.exc_info,
+                )
+            };
+
+            if rv != 0 {
+                return self.exc_info.as_err();
+            }
+        } else if T::DATA_TYPE == glue::GlueDataType::TpArrayString {
+            let glue_strings = T::casatables_stringvec_pass_through_out(value);
+
+            let rv = unsafe {
+                glue::tabledesc_put_column_keyword(
+                    self.handle,
+                    &ccol_name,
+                    &ckw_name,
+                    T::DATA_TYPE,
+                    shape.len() as u64,
+                    shape.as_ptr(),
+                    glue_strings.as_ptr() as _,
+                    &mut self.exc_info,
+                )
+            };
+
+            if rv != 0 {
+                return self.exc_info.as_err();
+            }
+        } else {
+            let rv = unsafe {
+                glue::tabledesc_put_column_keyword(
+                    self.handle,
+                    &ccol_name,
+                    &ckw_name,
+                    T::DATA_TYPE,
+                    shape.len() as u64,
+                    shape.as_ptr(),
+                    value.casatables_as_buf() as _,
+                    &mut self.exc_info,
+                )
+            };
+
+            if rv != 0 {
+                return self.exc_info.as_err();
+            }
         }
 
         Ok(())
@@ -760,6 +944,11 @@ pub struct UnexpectedDataTypeError(glue::GlueDataType, glue::GlueDataType);
 /// For details on the casacore tables, see the [documentation](https://casacore.github.io/casacore/group__Tables__module.html#details)
 impl Table {
     /// Create a new casacore table
+    ///
+    /// To open an existing table, use [`Table::open`]
+    ///
+    /// Read more about the casacore tables interface
+    /// [here](https://casacore.github.io/casacore/group__Tables__module.html#details)
     ///
     /// # Examples
     ///
@@ -825,10 +1014,13 @@ impl Table {
         })
     }
 
-    /// Open an existing casacore table
+    /// Open an existing casacore table.
     ///
-    /// to create a table, use `Table::new`, instead of `Table::open` with
-    /// `mode = TableOpenMode::Create`
+    /// To create a table, use [`Table::new`] instead of [`Table::open`] with
+    /// [`TableOpenMode::Create`]
+    ///
+    /// Read more about the casacore tables interface
+    /// [here](https://casacore.github.io/casacore/group__Tables__module.html#details)
     ///
     /// # Examples
     ///
@@ -861,6 +1053,10 @@ impl Table {
     /// let extracted_cell_value: Vec<f64> = table.get_cell_as_vec("UVW", 0).unwrap();
     /// assert_eq!(cell_value, extracted_cell_value);
     /// ```
+    ///     
+    /// # Errors
+    ///
+    /// Can raise [`CasacoreError`] if there was an issue invoking casacore
     pub fn open<P: AsRef<Path>>(path: P, mode: TableOpenMode) -> Result<Self, Error> {
         let spath = match path.as_ref().to_str() {
             Some(s) => s,
@@ -890,14 +1086,21 @@ impl Table {
         })
     }
 
+    /// The number of rows in the table
     pub fn n_rows(&self) -> u64 {
         unsafe { glue::table_n_rows(self.handle) as u64 }
     }
 
+    /// The number of columns in the table
     pub fn n_columns(&self) -> usize {
         unsafe { glue::table_n_columns(self.handle) as usize }
     }
 
+    /// A vector containing all of the column names in the table
+    ///
+    /// # Errors
+    ///
+    /// Can raise [`CasacoreError`] if there was an issue invoking casacore
     pub fn column_names(&mut self) -> Result<Vec<String>, CasacoreError> {
         let n_cols = self.n_columns();
         let mut cnames = Vec::with_capacity(n_cols);
@@ -915,6 +1118,11 @@ impl Table {
         Ok(cnames)
     }
 
+    /// Remove a column from the table
+    ///
+    /// # Errors
+    ///
+    /// Can raise [`CasacoreError`] if there was an issue invoking casacore
     pub fn remove_column(&mut self, col_name: &str) -> Result<(), CasacoreError> {
         let ccol_name = glue::StringBridge::from_rust(col_name);
 
@@ -927,6 +1135,15 @@ impl Table {
         Ok(())
     }
 
+    /// Add a scalar column to the table.
+    ///
+    /// `col_name` - column name, must be unique
+    /// `comment` - optional string field describing how to use the column.
+    /// `direct` -
+    ///
+    /// # Errors
+    ///
+    /// Can raise [`CasacoreError`] if there was an issue invoking casacore
     pub fn add_scalar_column(
         &mut self,
         data_type: glue::GlueDataType,
@@ -1015,11 +1232,14 @@ impl Table {
         Ok(())
     }
 
+    /// Return all of the names of keywords whose values are type `TpTable`.
+    ///
+    /// TODO: move this into `TableRecord`?
     pub fn table_keyword_names(&mut self) -> Result<Vec<String>, CasacoreError> {
         let mut result = Vec::new();
 
         let rv = unsafe {
-            invoke_table_get_keyword_info(self.handle, &mut self.exc_info, |name, dtype| {
+            invoke_table_get_keyword_info(self.handle, &mut self.exc_info, |name, dtype, _| {
                 if dtype == glue::GlueDataType::TpTable {
                     result.push(name);
                 }
@@ -1033,10 +1253,11 @@ impl Table {
         Ok(result)
     }
 
-    pub fn put_table_keyword(&mut self, kw_name: &str, table: Table) -> Result<(), CasacoreError> {
-        let ckw_name = glue::StringBridge::from_rust(kw_name);
+    pub fn keyword_dump(&mut self) -> Result<(), CasacoreError> {
         let rv = unsafe {
-            glue::table_put_keyword(self.handle, &ckw_name, glue::GlueDataType::TpTable, table.handle as _, &mut self.exc_info)
+            invoke_table_get_keyword_info(self.handle, &mut self.exc_info, |name, dtype, repr| {
+                println!(" -> {}:{:?} = {}", name, dtype, repr);
+            })
         };
 
         if rv != 0 {
@@ -1044,6 +1265,79 @@ impl Table {
         }
 
         Ok(())
+    }
+
+    pub fn column_keyword_dump(&mut self, col_name: &str) -> Result<(), CasacoreError> {
+        let ccol_name = glue::StringBridge::from_rust(col_name);
+
+        let rv = unsafe {
+            invoke_table_get_column_keyword_info(
+                self.handle,
+                &ccol_name,
+                &mut self.exc_info,
+                |name, dtype, repr| {
+                    println!(" -> {}:{:?} = {}", name, dtype, repr);
+                },
+            )
+        };
+
+        if rv != 0 {
+            return self.exc_info.as_err();
+        }
+
+        Ok(())
+    }
+
+    /// Define a keyword of type `TpTable` in this table
+    ///
+    /// TODO: move this into `TableRecord`?
+    pub fn put_table_keyword(&mut self, kw_name: &str, table: Table) -> Result<(), CasacoreError> {
+        let ckw_name = glue::StringBridge::from_rust(kw_name);
+        let shape = Vec::new();
+        let rv = unsafe {
+            glue::table_put_keyword(
+                self.handle,
+                &ckw_name,
+                glue::GlueDataType::TpTable,
+                shape.len() as _,
+                shape.as_ptr(),
+                table.handle as _,
+                &mut self.exc_info,
+            )
+        };
+
+        if rv != 0 {
+            return self.exc_info.as_err();
+        }
+
+        Ok(())
+    }
+
+    /// Return a TableRecord containing all keyword / value pairs for this table
+    pub fn get_keyword_record(&mut self) -> Result<TableRecord, CasacoreError> {
+        let handle = unsafe { glue::table_get_keywords(self.handle, &mut self.exc_info) };
+
+        if handle.is_null() {
+            return self.exc_info.as_err();
+        }
+
+        TableRecord::copy_handle(unsafe { &*handle })
+    }
+
+    /// Return a TableRecord containing all keyword / value pairs for this table
+    pub fn get_column_keyword_record(
+        &mut self,
+        col_name: &str,
+    ) -> Result<TableRecord, CasacoreError> {
+        let ccol_name = glue::StringBridge::from_rust(col_name);
+        let handle =
+            unsafe { glue::table_get_column_keywords(self.handle, &ccol_name, &mut self.exc_info) };
+
+        if handle.is_null() {
+            return self.exc_info.as_err();
+        }
+
+        TableRecord::copy_handle(unsafe { &*handle })
     }
 
     pub fn get_col_desc(&mut self, col_name: &str) -> Result<ColumnDescription, CasacoreError> {
@@ -1773,6 +2067,295 @@ impl Drop for TableRow {
     }
 }
 
+#[derive(Clone)]
+pub struct TableRecord {
+    handle: *mut glue::GlueTableRecord,
+    exc_info: glue::ExcInfo,
+}
+
+impl TableRecord {
+    pub fn new() -> Result<Self, Error> {
+        let mut exc_info = unsafe { std::mem::zeroed::<glue::ExcInfo>() };
+
+        let handle = unsafe { glue::tablerec_create(&mut exc_info) };
+        if handle.is_null() {
+            return exc_info.as_err();
+        }
+
+        Ok(Self { handle, exc_info })
+    }
+
+    pub fn copy_handle(other_handle: &glue::GlueTableRecord) -> Result<Self, CasacoreError> {
+        let mut exc_info = unsafe { std::mem::zeroed::<glue::ExcInfo>() };
+
+        let handle = unsafe { glue::tablerec_copy(other_handle, &mut exc_info) };
+        if handle.is_null() {
+            return exc_info.as_err();
+        }
+
+        Ok(Self { handle, exc_info })
+    }
+
+    /// Return all of the keyword names in the record.
+    pub fn keyword_names(&mut self) -> Result<Vec<String>, CasacoreError> {
+        let mut result = Vec::new();
+
+        let rv = unsafe {
+            invoke_tablerec_get_keyword_info(self.handle, &mut self.exc_info, |name, _, _| {
+                result.push(name);
+            })
+        };
+
+        if rv != 0 {
+            return self.exc_info.as_err();
+        }
+
+        Ok(result)
+    }
+
+    /// Dump all of the keywords in the record.
+    pub fn keyword_dump(&mut self) -> Result<(), CasacoreError> {
+        let rv = unsafe {
+            invoke_tablerec_get_keyword_info(
+                self.handle,
+                &mut self.exc_info,
+                |name, dtype, repr| {
+                    println!(" -> {}:{:?} = {}", name, dtype, repr);
+                },
+            )
+        };
+
+        if rv != 0 {
+            return self.exc_info.as_err();
+        }
+
+        Ok(())
+    }
+
+    pub fn get_field<T: CasaDataType>(&mut self, col_name: &str) -> Result<T, Error> {
+        let ccol_name = glue::StringBridge::from_rust(col_name);
+        let mut data_type = glue::GlueDataType::TpOther;
+        let mut n_dim = 0;
+        let mut dims = [0; 8];
+
+        let rv = unsafe {
+            glue::tablerec_get_field_info(
+                self.handle,
+                &ccol_name,
+                &mut data_type,
+                &mut n_dim,
+                dims.as_mut_ptr(),
+                &mut self.exc_info,
+            )
+        };
+
+        if rv != 0 {
+            return self.exc_info.as_err();
+        }
+
+        if data_type != T::DATA_TYPE {
+            return Err(UnexpectedDataTypeError(T::DATA_TYPE, data_type).into());
+        }
+
+        let result = if data_type == glue::GlueDataType::TpString {
+            let mut value = None;
+
+            let rv = unsafe {
+                invoke_tablerec_get_field_string(self.handle, &ccol_name, &mut self.exc_info, |v| {
+                    value = Some(v);
+                })
+            };
+
+            if rv != 0 {
+                return self.exc_info.as_err();
+            }
+
+            T::casatables_string_pass_through(value.unwrap())
+        } else if data_type == glue::GlueDataType::TpArrayString {
+            let mut result = Vec::new();
+
+            let rv = unsafe {
+                invoke_tablerec_get_field_string_array(
+                    self.handle,
+                    &ccol_name,
+                    &mut self.exc_info,
+                    |v| {
+                        result.push(v);
+                    },
+                )
+            };
+
+            if rv != 0 {
+                return self.exc_info.as_err();
+            }
+
+            T::casatables_stringvec_pass_through(result)
+        } else if data_type == glue::GlueDataType::TpRecord {
+            let result = TableRecord::new().unwrap();
+            let rv = unsafe {
+                glue::tablerec_get_field_subrecord(
+                    self.handle,
+                    &ccol_name,
+                    result.handle,
+                    &mut self.exc_info,
+                )
+            };
+
+            if rv != 0 {
+                return self.exc_info.as_err();
+            }
+
+            T::casatables_tablerec_pass_through(result)
+        } else {
+            let mut result = T::casatables_alloc(&dims[..n_dim as usize])?;
+
+            let rv = unsafe {
+                glue::tablerec_get_field(
+                    self.handle,
+                    &ccol_name,
+                    result.casatables_as_mut_buf() as _,
+                    &mut self.exc_info,
+                )
+            };
+
+            if rv != 0 {
+                return self.exc_info.as_err();
+            }
+
+            result
+        };
+
+        Ok(result)
+    }
+
+    /// Note: I am not sure if this function actually works. `Table.put_cell`
+    /// does work. Investigation required.
+    pub fn put_field<T: CasaDataType>(
+        &mut self,
+        field_name: &str,
+        value: &T,
+    ) -> Result<(), CasacoreError> {
+        let cfield_name = glue::StringBridge::from_rust(field_name);
+        let mut shape = Vec::new();
+
+        value.casatables_put_shape(&mut shape);
+
+        if T::DATA_TYPE == glue::GlueDataType::TpString {
+            let as_string = T::casatables_string_pass_through_out(value);
+            let glue_string = glue::StringBridge::from_rust(&as_string);
+
+            let rv = unsafe {
+                glue::tablerec_put_field(
+                    self.handle,
+                    &cfield_name,
+                    T::DATA_TYPE,
+                    shape.len() as u64,
+                    shape.as_ptr(),
+                    &glue_string as *const glue::StringBridge as _,
+                    &mut self.exc_info,
+                )
+            };
+
+            if rv != 0 {
+                return self.exc_info.as_err();
+            }
+        } else if T::DATA_TYPE == glue::GlueDataType::TpArrayString {
+            let glue_strings = T::casatables_stringvec_pass_through_out(value);
+
+            let rv = unsafe {
+                glue::tablerec_put_field(
+                    self.handle,
+                    &cfield_name,
+                    T::DATA_TYPE,
+                    shape.len() as u64,
+                    shape.as_ptr(),
+                    glue_strings.as_ptr() as _,
+                    &mut self.exc_info,
+                )
+            };
+
+            if rv != 0 {
+                return self.exc_info.as_err();
+            }
+        } else {
+            let rv = unsafe {
+                glue::tablerec_put_field(
+                    self.handle,
+                    &cfield_name,
+                    T::DATA_TYPE,
+                    shape.len() as u64,
+                    shape.as_ptr(),
+                    value.casatables_as_buf() as _,
+                    &mut self.exc_info,
+                )
+            };
+
+            if rv != 0 {
+                return self.exc_info.as_err();
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl PartialEq for TableRecord {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { glue::tablerec_eq(self.handle, other.handle) }
+    }
+}
+
+impl CasaDataType for TableRecord {
+    const DATA_TYPE: glue::GlueDataType = glue::GlueDataType::TpRecord;
+
+    fn casatables_alloc(_shape: &[u64]) -> Result<Self, Error> {
+        TableRecord::new()
+    }
+
+    fn casatables_as_buf(&self) -> *const () {
+        self.handle as _
+    }
+
+    fn casatables_as_mut_buf(&mut self) -> *mut () {
+        self.handle as _
+    }
+
+    /// A hack that lets us properly special-case table records.
+    #[doc(hidden)]
+    fn casatables_tablerec_pass_through(r: TableRecord) -> Self {
+        r
+    }
+
+    /// A hack that lets us properly special-case table records
+    #[doc(hidden)]
+    fn casatables_tablerec_pass_through_out(s: &Self) -> TableRecord {
+        s.to_owned()
+    }
+}
+
+impl Drop for TableRecord {
+    fn drop(&mut self) {
+        // TODO: we want to free standalone tablerecords, but not those which
+        // are associated with a table, because they are freed automatically
+        // with the table. Not sure the best way to do this.
+
+        // FIXME: not sure if this function can actually produce useful
+        // exceptions anyway, but we can't do anything if it does!
+        unsafe {
+            glue::tablerec_free(self.handle, &mut self.exc_info);
+        }
+    }
+}
+
+// /// represents a MEAS_INFO record for a column whose measure type is determined
+// /// by a different column in the table.
+// pub struct ColMeasInfoRecord<C> {
+//     measure_type: String,
+//     measure_ref_col: String,
+//     ref_types: Vec<String>,
+//     ref_codes: Vec<C>,
+// }
+
 #[cfg(test)]
 mod tests {
     use std::fs::OpenOptions;
@@ -2148,7 +2731,7 @@ mod tests {
         assert_eq!(aparams_tabledesc.shape(), None);
         assert!(!aparams_tabledesc.is_fixed_shape());
         assert!(!aparams_tabledesc.is_scalar());
-        
+
         let cell_value_read: Vec<String> = table.get_cell_as_vec("APP_PARAMS", 0).unwrap();
         assert_eq!(cell_value_read, cell_value);
     }
@@ -2173,14 +2756,82 @@ mod tests {
             )
             .unwrap();
         // Create your new table with 1 rows
-        let mut root_table = Table::new(&root_table_path, root_table_desc, 1, TableCreateMode::New).unwrap();
+        let mut root_table =
+            Table::new(&root_table_path, root_table_desc, 1, TableCreateMode::New).unwrap();
 
         let mut sub_table_desc = TableDesc::new("", TableDescCreateMode::TDM_SCRATCH).unwrap();
-        sub_table_desc.add_scalar_column(GlueDataType::TpInt, "int", None, true, false).unwrap();
+        sub_table_desc
+            .add_scalar_column(GlueDataType::TpInt, "int", None, true, false)
+            .unwrap();
 
-        let sub_table = Table::new(&sub_table_path, sub_table_desc, 1, TableCreateMode::New).unwrap();
+        let sub_table =
+            Table::new(&sub_table_path, sub_table_desc, 1, TableCreateMode::New).unwrap();
         root_table.put_table_keyword("SUB", sub_table).unwrap();
-        
+
         assert_eq!(root_table.table_keyword_names().unwrap(), ["SUB"]);
+    }
+
+    #[test]
+    pub fn tabledesc_put_frequency_meas_desc() {
+        let tmp_dir = tempdir().unwrap();
+        let root_table_path = tmp_dir.path().join("test.ms");
+        let source_table_path = root_table_path.join("SOURCE");
+        // First create a table description for our base table.
+        // Use TDM_SCRATCH to avoid writing the .tabdsc to disk.
+        let root_table_desc = TableDesc::new("", TableDescCreateMode::TDM_SCRATCH).unwrap();
+        Table::new(&root_table_path, root_table_desc, 1, TableCreateMode::New).unwrap();
+
+        let mut source_table_desc = TableDesc::new("", TableDescCreateMode::TDM_SCRATCH).unwrap();
+        source_table_desc
+            .add_array_column(
+                glue::GlueDataType::TpDouble,
+                "REST_FREQUENCY",
+                None,
+                None,
+                false,
+                false,
+            )
+            .unwrap();
+
+        source_table_desc
+            .put_column_keyword("REST_FREQUENCY", "QuantumUnits", &vec!["Hz".to_string()])
+            .unwrap();
+
+        let mut meas_info = TableRecord::new().unwrap();
+        meas_info
+            .put_field("type", &"frequency".to_string())
+            .unwrap();
+        meas_info.put_field("Ref", &"LSRK".to_string()).unwrap();
+
+        source_table_desc
+            .put_column_keyword("REST_FREQUENCY", "MEASINFO", &meas_info)
+            .unwrap();
+
+        let mut source_table = Table::new(
+            &source_table_path,
+            source_table_desc,
+            1,
+            TableCreateMode::New,
+        )
+        .unwrap();
+
+        let mut result_tablerec = source_table
+            .get_column_keyword_record("REST_FREQUENCY")
+            .unwrap();
+        let keywords = result_tablerec.keyword_names().unwrap();
+        assert_eq!(keywords, vec!["QuantumUnits", "MEASINFO"]);
+
+        let units: Vec<String> = result_tablerec.get_field("QuantumUnits").unwrap();
+        assert_eq!(units, ["Hz"]);
+
+        let mut result_meas_info: TableRecord = result_tablerec.get_field("MEASINFO").unwrap();
+
+        let result_meas_info_keywords = result_meas_info.keyword_names().unwrap();
+        assert_eq!(result_meas_info_keywords, vec!["type", "Ref"]);
+
+        let meas_type: String = result_meas_info.get_field("type").unwrap();
+        assert_eq!(meas_type, "frequency");
+        let meas_ref: String = result_meas_info.get_field("Ref").unwrap();
+        assert_eq!(meas_ref, "LSRK");
     }
 }


### PR DESCRIPTION
Draft PR to show what I'm doing with adding measures to fix #180 
I think the only feasible way of doing this would be to add a `tabledesc_create_<MType>_measure_desc` for all common measure types (`MFrequency`, `MEpoch` etc.)

I'm having an issue where it's complaining about incomplete types, but I can't figure it out. Any ideas why this won't compile @pkgw ?

```txt
  running: "c++" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "-m64" "-I" "src" "-I" "/home/dev/rubbl/target/debug/build/rubbl_casatables_impl-1be5e8d779e4705f/out/include" "-Wall" "-Wextra" "-std=c++11" "-Dcasacore=rubbl_casacore" "-o" "/home/dev/rubbl/target/debug/build/rubbl_casatables-0d8348072dd75962/out/src/glue.o" "-c" "src/glue.cc"
  cargo:warning=src/glue.cc:25:51: error: ‘rubbl_casacore::MFrequency::Types’ has not been declared
  cargo:warning=   25 | #define GlueMFrequencyTypes casacore::MFrequency::Types  cargo:warning=      |                                                   ^~~~~
  cargo:warning=src/glue.cc:385:9: note: in expansion of macro ‘GlueMFrequencyTypes’
  cargo:warning=  385 |         GlueMFrequencyTypes type,
  cargo:warning=      |         ^~~~~~~~~~~~~~~~~~~  cargo:warning=In file included from /home/dev/rubbl/target/debug/build/rubbl_casatables_impl-1be5e8d779e4705f/out/include/casacore/measures/TableMeasures/TableMeasDesc.h:299,
  cargo:warning=                 from /home/dev/rubbl/target/debug/build/rubbl_casatables_impl-1be5e8d779e4705f/out/include/casacore/measures/TableMeasures.h:36,
  cargo:warning=                 from src/glue.cc:12:  cargo:warning=/home/dev/rubbl/target/debug/build/rubbl_casatables_impl-1be5e8d779e4705f/out/include/casacore/measures/TableMeasures/TableMeasDesc.tcc: In instantiation of ‘rubbl_casacore::TableMeasDesc<M>::TableMeasDesc(const rubbl_casacore::TableMeasValueDesc&, const rubbl_casacore::TableMeasRefDesc&, const rubbl_casacore::Vector<rubbl_casacore::Unit>&) [with M = rubbl_casacore::MFrequency]’:
  cargo:warning=src/glue.cc:401:92:   required from here  cargo:warning=/home/dev/rubbl/target/debug/build/rubbl_casatables_impl-1be5e8d779e4705f/out/include/casacore/measures/TableMeasures/TableMeasDesc.tcc:88:5: error: ‘rubbl_casacore::MFrequency meas’ has incomplete type
  cargo:warning=   88 |   M meas;
  cargo:warning=      |     ^~~~
  cargo:warning=/home/dev/rubbl/target/debug/build/rubbl_casatables_impl-1be5e8d779e4705f/out/include/casacore/measures/TableMeasures/TableMeasDesc.tcc: In instantiation of ‘rubbl_casacore::TableMeasDesc<M>::TableMeasDesc(const rubbl_casacore::TableMeasValueDesc&, const rubbl_casacore::TableMeasRefDesc&) [with M = rubbl_casacore::MFrequency]’:
  cargo:warning=src/glue.cc:403:80:   required from here
  cargo:warning=/home/dev/rubbl/target/debug/build/rubbl_casatables_impl-1be5e8d779e4705f/out/include/casacore/measures/TableMeasures/TableMeasDesc.tcc:71:5: error: ‘rubbl_casacore::MFrequency meas’ has incomplete type
  cargo:warning=   71 |   M meas;
  cargo:warning=      |     ^~~~
  cargo:warning=src/glue.cc: In function ‘rubbl_casacore::TableMeasDesc<rubbl_casacore::MFrequency>* tabledesc_create_frequency_measure_desc(rubbl_casacore::TableDesc&, const StringBridge&, int, long unsigned int, const rubbl_casacore::Unit*, ExcInfo&)’:
  cargo:warning=src/glue.cc:409:5: warning: control reaches end of non-void function [-Wreturn-type]  cargo:warning=  409 |     }
  cargo:warning=      |     ^
  exit status: 1

```

Alternatively, because this whole measure type conversion system is just so needlessly complicated, I might see if I can write the equivalent metadata directly into a MEAS_INFO record and bypass all the type juggling insanity.