### PR TITLE
failure -> thiserror/anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "anyhow"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,17 +34,6 @@ checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-complex",
  "num-traits",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -88,13 +86,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.0.26"
+version = "4.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
+checksum = "0acbd8d28a0a60d7108d7ae850af6ba34cf2d1257fc646980e5f97ce14275966"
 dependencies = [
- "atty",
  "bitflags",
  "clap_lex",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
@@ -121,33 +119,32 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
+name = "errno"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
 dependencies = [
- "backtrace",
- "failure_derive",
+ "errno-dragonfly",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
-name = "failure_derive"
-version = "0.1.8"
+name = "errno-dragonfly"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -167,9 +164,9 @@ checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -184,6 +181,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e394faa0efb47f9f227f1cd89978f854542b318a6f64fa695489c9c993056656"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae5bc6e2eb41c9def29a3e0f1306382807764b9b53112030eff57435667352d"
+dependencies = [
+ "hermit-abi",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,9 +213,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
 
 [[package]]
 name = "matrixmultiply"
@@ -274,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "openat"
@@ -289,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "pbr"
@@ -307,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -351,24 +376,24 @@ dependencies = [
 name = "rubbl"
 version = "0.0.0-dev.0"
 dependencies = [
+ "anyhow",
  "clap",
- "failure",
- "failure_derive",
  "rubbl_core",
+ "thiserror",
 ]
 
 [[package]]
 name = "rubbl_casatables"
 version = "0.0.0-dev.0"
 dependencies = [
+ "anyhow",
  "cc",
  "clap",
- "failure",
- "failure_derive",
  "ndarray",
  "rubbl_casatables_impl",
  "rubbl_core",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -382,45 +407,46 @@ dependencies = [
 name = "rubbl_core"
 version = "0.0.0-dev.0"
 dependencies = [
+ "anyhow",
  "approx",
  "byteorder",
  "clap",
- "failure",
- "failure_derive",
  "ndarray",
  "num-complex",
  "termcolor",
+ "thiserror",
 ]
 
 [[package]]
 name = "rubbl_fits"
 version = "0.0.0-dev.0"
 dependencies = [
+ "anyhow",
  "clap",
- "failure",
- "failure_derive",
  "rubbl_core",
  "rubbl_visdata",
+ "thiserror",
 ]
 
 [[package]]
 name = "rubbl_miriad"
 version = "0.0.0-dev.0"
 dependencies = [
+ "anyhow",
  "byteorder",
  "clap",
- "failure",
- "failure_derive",
  "openat",
  "pbr",
  "rubbl_core",
  "rubbl_visdata",
+ "thiserror",
 ]
 
 [[package]]
 name = "rubbl_visdata"
 version = "0.0.0-dev.0"
 dependencies = [
+ "anyhow",
  "rubbl_core",
 ]
 
@@ -431,6 +457,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
+name = "rustix"
+version = "0.36.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1fbb4dfc4eb1d390c02df47760bb19a84bb80b301ecc947ab5406394d8223e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,25 +478,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
 ]
 
 [[package]]
@@ -483,10 +511,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.44"
+name = "thiserror"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi",
@@ -495,15 +543,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "wasi"
@@ -541,3 +583,60 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,16 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-complex",
- "num-traits",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,7 +398,6 @@ name = "rubbl_core"
 version = "0.0.0-dev.0"
 dependencies = [
  "anyhow",
- "approx",
  "byteorder",
  "clap",
  "ndarray",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,9 +478,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/casatables/Cargo.toml
+++ b/casatables/Cargo.toml
@@ -18,15 +18,15 @@ rubbl_casatables_impl = "thiscommit:2021-11-04:9Lgzrtq"
 rubbl_core = "thiscommit:2020-12-15:EiT8sa0a"
 
 [dependencies]
-ndarray = ">=0.8"
+ndarray = "0.15.0"
 rubbl_casatables_impl = { version ="0.0.0-dev.0", path = "../casatables_impl" }
 rubbl_core = { version ="0.0.0-dev.0", path = "../core" }
-thiserror = "^1.0"
+thiserror = "1.0.7"
 
 [build-dependencies]
-cc = { version = "1.0", features = ["parallel"] }
+cc = { version = "1.0.42", features = ["parallel"] }
 
 [dev-dependencies]
-anyhow = "^1.0"
-clap = { version = "^4", features = ["cargo"] }
-tempfile = "3.3"
+anyhow = "1.0.0"
+clap = { version = "4.0.26", features = ["cargo"] }
+tempfile = "3.3.0"

--- a/casatables/Cargo.toml
+++ b/casatables/Cargo.toml
@@ -18,15 +18,15 @@ rubbl_casatables_impl = "thiscommit:2021-11-04:9Lgzrtq"
 rubbl_core = "thiscommit:2020-12-15:EiT8sa0a"
 
 [dependencies]
-failure = "^0.1"
-failure_derive = "^0.1"
 ndarray = ">=0.8"
 rubbl_casatables_impl = { version ="0.0.0-dev.0", path = "../casatables_impl" }
 rubbl_core = { version ="0.0.0-dev.0", path = "../core" }
+thiserror = "^1.0"
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
 
 [dev-dependencies]
+anyhow = "^1.0"
 clap = { version = "^4", features = ["cargo"] }
 tempfile = "3.3"

--- a/casatables/Cargo.toml
+++ b/casatables/Cargo.toml
@@ -29,4 +29,5 @@ cc = { version = "1.0.42", features = ["parallel"] }
 [dev-dependencies]
 anyhow = "1.0.0"
 clap = { version = "4.0.26", features = ["cargo"] }
+rubbl_core = { version ="0.0.0-dev.0", path = "../core", features = ["notifications"] }
 tempfile = "3.3.0"

--- a/casatables/README.md
+++ b/casatables/README.md
@@ -1,3 +1,9 @@
 # `rubbl_casatables`
 
 A Rust interface to the CASA table format.
+
+See [the `rubbl_core` README on Crates.io][1] for a discussion of crate
+duplication issues that may arise with key dependencies such as [`ndarray`][2].
+
+[1]: https://crates.io/crates/rubbl_core/
+[2]: https://crates.io/crates/ndarray/

--- a/casatables/examples/tableinfo.rs
+++ b/casatables/examples/tableinfo.rs
@@ -1,12 +1,12 @@
-// Copyright 2017 Peter Williams <peter@newton.cx> and collaborators
+// Copyright 2017-2023 Peter Williams <peter@newton.cx> and collaborators
 // Licensed under the MIT License.
 
 //! Summarize the structure of a CASA table.
 
-use anyhow::{Context, Error};
+use anyhow::Error;
 use clap::{Arg, Command};
 use rubbl_casatables::{Table, TableOpenMode};
-use rubbl_core::notify::ClapNotificationArgsExt;
+use rubbl_core::{ctry, notify::ClapNotificationArgsExt};
 use std::{cmp::max, path::PathBuf, process};
 
 fn main() {
@@ -26,30 +26,30 @@ fn main() {
         |matches, _nbe| -> Result<i32, Error> {
             let inpath = matches.get_one::<PathBuf>("IN-TABLE").unwrap();
 
-            let mut t = Table::open(&inpath, TableOpenMode::Read)
-                .with_context(|| format!("failed to open input table \"{}\"", inpath.display()))?;
+            let mut t = ctry!(
+                Table::open(&inpath, TableOpenMode::Read);
+                "failed to open input table \"{}\"", inpath.display()
+            );
 
             println!("Table \"{}\":", inpath.display());
             println!("Number of rows: {}", t.n_rows());
             println!("Number of columns: {}", t.n_columns());
             println!("");
 
-            let col_names = t.column_names().with_context(|| {
-                format!("failed to get names of columns in \"{}\"", inpath.display())
-            })?;
+            let col_names = ctry!(
+                t.column_names();
+                "failed to get names of columns in \"{}\"", inpath.display()
+            );
 
             let mut max_name_len = 0;
             let mut max_type_len = 0;
             let mut info: Vec<(&str, String, String)> = Vec::new();
 
             for n in &col_names {
-                let desc = t.get_col_desc(&n).with_context(|| {
-                    format!(
-                        "failed to query column \"{}\" in \"{}\"",
-                        n,
-                        inpath.display()
-                    )
-                })?;
+                let desc = ctry!(
+                    t.get_col_desc(&n);
+                    "failed to query column \"{}\" in \"{}\"", n, inpath.display()
+                );
 
                 let type_text = format!("{}", desc.data_type());
 
@@ -74,9 +74,10 @@ fn main() {
                 );
             }
 
-            let table_kw_names = t.table_keyword_names().with_context(|| {
-                format!("failed to get keyword info in \"{}\"", inpath.display())
-            })?;
+            let table_kw_names = ctry!(
+                t.table_keyword_names();
+                "failed to get keyword info in \"{}\"", inpath.display()
+            );
 
             if table_kw_names.len() != 0 {
                 println!();

--- a/casatables/src/glue.cc
+++ b/casatables/src/glue.cc
@@ -254,8 +254,11 @@ extern "C" {
             const casacore::RecordDesc &desc = rec.description();
             casacore::Int field_num = rec.fieldNumber(bridge_string(col_name));
 
-            if (field_num < 0)
-                throw std::runtime_error("unrecognized column name");
+            if (field_num < 0) {
+                std::string s = "unrecognized column name: ";
+                s.append(bridge_string(col_name));
+                throw std::runtime_error(s);
+            }
 
             *data_type = rec.type(field_num);
 
@@ -289,8 +292,11 @@ extern "C" {
             casacore::Int field_num = rec.fieldNumber(bridge_string(field_name));
             casacore::IPosition shape;
 
-            if (field_num < 0)
-                throw std::runtime_error("unrecognized keyword name");
+            if (field_num < 0) {
+                std::string s = "unrecognized keyword name: ";
+                s.append(bridge_string(field_name));
+                throw std::runtime_error(s);
+            }
 
             if (!desc.isScalar(field_num)) {                
                 shape = rec.shape(field_num);
@@ -369,8 +375,11 @@ extern "C" {
         try {
             casacore::Int field_num = rec.fieldNumber(bridge_string(col_name));
 
-            if (field_num < 0)
-                throw std::runtime_error("unrecognized keyword name");
+            if (field_num < 0) {
+                std::string s = "unrecognized keyword name: ";
+                s.append(bridge_string(col_name));
+                throw std::runtime_error(s);
+            }
 
             if (rec.type(field_num) != casacore::TpString)
                 throw std::runtime_error("tablerec cell must be of TpString type");
@@ -398,8 +407,11 @@ extern "C" {
         try {
             casacore::Int field_num = rec.fieldNumber(bridge_string(col_name));
 
-            if (field_num < 0)
-                throw std::runtime_error("unrecognized column name");
+            if (field_num < 0) {
+                std::string s = "unrecognized column name: ";
+                s.append(bridge_string(col_name));
+                throw std::runtime_error(s);
+            }
 
             casacore::IPosition shape = rec.shape(field_num);
 
@@ -428,9 +440,11 @@ extern "C" {
         try {
             casacore::Int field_num = rec.fieldNumber(bridge_string(col_name));
 
-            if (field_num < 0)
-                throw std::runtime_error("unrecognized column name");
-
+            if (field_num < 0) {
+                std::string s = "unrecognized column name: ";
+                s.append(bridge_string(col_name));
+                throw std::runtime_error(s);
+            }
 
             if (rec.type(field_num) != casacore::TpRecord)
                 throw std::runtime_error("row cell must be of TpRecord type");

--- a/casatables/src/lib.rs
+++ b/casatables/src/lib.rs
@@ -29,14 +29,13 @@
 
 #![deny(missing_docs)]
 
-use failure::{err_msg, Error};
-use failure_derive::Fail;
 use ndarray::Dimension;
 use rubbl_core::num::{DimFromShapeSlice, DimensionMismatchError};
 use std::{
     fmt::{self, Debug},
     path::Path,
 };
+use thiserror::Error;
 
 pub use rubbl_core::{Array, Complex};
 
@@ -48,8 +47,8 @@ pub use glue::{GlueDataType, TableDescCreateMode};
 
 /// An error type used when the wrapped "casacore" C++ code raises an
 /// exception.
-#[derive(Fail, Debug)]
-#[fail(display = "{}", _0)]
+#[derive(Error, Debug)]
+#[error("{0}")]
 pub struct CasacoreError(String);
 
 impl glue::ExcInfo {
@@ -178,7 +177,7 @@ pub trait CasaDataType: Clone + PartialEq + Sized {
     }
 
     #[doc(hidden)]
-    fn casatables_alloc(shape: &[u64]) -> Result<Self, Error>;
+    fn casatables_alloc(shape: &[u64]) -> Result<Self, TableError>;
 
     #[doc(hidden)]
     fn casatables_as_buf(&self) -> *const () {
@@ -203,7 +202,7 @@ macro_rules! impl_scalar_data_type {
         impl CasaDataType for $rust_type {
             const DATA_TYPE: glue::GlueDataType = glue::GlueDataType::$casa_scalar_type;
 
-            fn casatables_alloc(_shape: &[u64]) -> Result<Self, Error> {
+            fn casatables_alloc(_shape: &[u64]) -> Result<Self, TableError> {
                 Ok($default)
             }
         }
@@ -238,7 +237,7 @@ impl CasaDataType for String {
         s.to_owned()
     }
 
-    fn casatables_alloc(_shape: &[u64]) -> Result<Self, Error> {
+    fn casatables_alloc(_shape: &[u64]) -> Result<Self, TableError> {
         Ok("".to_owned())
     }
 
@@ -264,7 +263,7 @@ macro_rules! impl_vec_data_type {
         impl CasaDataType for Vec<$rust_type> {
             const DATA_TYPE: glue::GlueDataType = glue::GlueDataType::$casa_type;
 
-            fn casatables_alloc(shape: &[u64]) -> Result<Self, Error> {
+            fn casatables_alloc(shape: &[u64]) -> Result<Self, TableError> {
                 if shape.len() != 1 {
                     Err(DimensionMismatchError {
                         expected: 1,
@@ -312,7 +311,7 @@ impl_vec_data_type! { Complex<f64>, TpArrayDComplex }
 impl CasaDataType for Vec<String> {
     const DATA_TYPE: glue::GlueDataType = glue::GlueDataType::TpArrayString;
 
-    fn casatables_alloc(shape: &[u64]) -> Result<Self, Error> {
+    fn casatables_alloc(shape: &[u64]) -> Result<Self, TableError> {
         if shape.len() != 1 {
             Err(DimensionMismatchError {
                 expected: 1,
@@ -356,7 +355,7 @@ impl CasaDataType for Vec<String> {
 impl<I: CasaScalarData + Copy, D: Dimension + DimFromShapeSlice<u64>> CasaDataType for Array<I, D> {
     const DATA_TYPE: glue::GlueDataType = I::VECTOR_TYPE;
 
-    fn casatables_alloc(shape: &[u64]) -> Result<Self, Error> {
+    fn casatables_alloc(shape: &[u64]) -> Result<Self, TableError> {
         // TODO: this method is deprecated and we are certainly in the danger
         // zone by producing uninitialized memory here. Need to figure out a
         // better approach. We may need to take a closure argument that we can
@@ -739,7 +738,7 @@ impl TableDesc {
     ///     however you most likely want to go with Scratch, as this avoids
     ///     writing a .tabdsc file to disk.
     ///
-    pub fn new(name: &str, mode: glue::TableDescCreateMode) -> Result<Self, Error> {
+    pub fn new(name: &str, mode: glue::TableDescCreateMode) -> Result<Self, TableError> {
         let cname = glue::StringBridge::from_rust(name);
         let mut exc_info = unsafe { std::mem::zeroed::<glue::ExcInfo>() };
 
@@ -760,7 +759,7 @@ impl TableDesc {
         comment: Option<&str>,
         direct: bool,
         undefined: bool,
-    ) -> Result<(), Error> {
+    ) -> Result<(), TableError> {
         let cname = glue::StringBridge::from_rust(col_name);
         let comment = if let Some(comment_) = comment {
             comment_
@@ -799,7 +798,7 @@ impl TableDesc {
         dims: Option<&[u64]>,
         direct: bool,
         undefined: bool,
-    ) -> Result<(), Error> {
+    ) -> Result<(), TableError> {
         let cname = glue::StringBridge::from_rust(col_name);
         let comment = if let Some(comment_) = comment {
             comment_
@@ -841,7 +840,7 @@ impl TableDesc {
     }
 
     /// Set the number of dimensions of a column
-    pub fn set_ndims(&mut self, col_name: &str, ndims: u64) -> Result<(), Error> {
+    pub fn set_ndims(&mut self, col_name: &str, ndims: u64) -> Result<(), TableError> {
         let cname = glue::StringBridge::from_rust(col_name);
         let rv =
             unsafe { glue::tabledesc_set_ndims(self.handle, &cname, ndims, &mut self.exc_info) };
@@ -1011,23 +1010,43 @@ pub enum TableCreateMode {
 }
 
 /// An error type used when a scalar column was expected but a vector was found.
-#[derive(Fail, Debug)]
-#[fail(
-    display = "Expected a column with a scalar data type, but found a vector of {}",
-    _0
-)]
+#[derive(Error, Debug)]
+#[error("Expected a column with a scalar data type, but found a vector of {0}")]
 pub struct NotScalarColumnError(glue::GlueDataType);
 
 /// An error type used when the expected data type was not found.
 ///
 /// The first element of the tuple is the expected data type, and the second
 /// element is the one that was actually encountered.
-#[derive(Fail, Debug)]
-#[fail(
-    display = "Expected data with the storage type {}, but found {}",
-    _0, _1
-)]
+#[derive(Error, Debug)]
+#[error("Expected data with the storage type {0}, but found {1}")]
 pub struct UnexpectedDataTypeError(glue::GlueDataType, glue::GlueDataType);
+
+/// An error type capturing all potential problems when interfacing with
+/// [`Table`]s.
+#[derive(Error, Debug)]
+pub enum TableError {
+    /// Table paths must be representable as UTF-8 strings.
+    #[error("table paths must be representable as UTF-8 strings")]
+    InvalidUtf8,
+
+    /// Expected a scalar, but got a vector.
+    #[error("Expected a column with a scalar data type, but found a vector of {0}")]
+    NotScalarColumnError(glue::GlueDataType),
+
+    /// Received a different type from what was expected.
+    #[error(transparent)]
+    UnexpectedDataType(#[from] UnexpectedDataTypeError),
+
+    /// Generic casacore C++ exception.
+    #[error(transparent)]
+    Casacore(#[from] CasacoreError),
+
+    /// An error type used when two arrays should have the same dimensionality,
+    /// but do not.
+    #[error(transparent)]
+    DimensionMismatch(#[from] DimensionMismatchError),
+}
 
 /// A Rust wrapper for a casacore table.
 ///
@@ -1080,13 +1099,11 @@ impl Table {
         table_desc: TableDesc,
         n_rows: usize,
         mode: TableCreateMode,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, TableError> {
         let spath = match path.as_ref().to_str() {
             Some(s) => s,
             None => {
-                return Err(err_msg(
-                    "table paths must be representable as UTF-8 strings",
-                ));
+                return Err(TableError::InvalidUtf8);
             }
         };
 
@@ -1175,14 +1192,10 @@ impl Table {
     /// # Errors
     ///
     /// Can raise [`CasacoreError`] if there was an issue invoking casacore.
-    pub fn open<P: AsRef<Path>>(path: P, mode: TableOpenMode) -> Result<Self, Error> {
+    pub fn open<P: AsRef<Path>>(path: P, mode: TableOpenMode) -> Result<Self, TableError> {
         let spath = match path.as_ref().to_str() {
             Some(s) => s,
-            None => {
-                return Err(err_msg(
-                    "table paths must be representable as UTF-8 strings",
-                ));
-            }
+            None => return Err(TableError::InvalidUtf8),
         };
         let cpath = glue::StringBridge::from_rust(spath);
         let mut exc_info = unsafe { std::mem::zeroed::<glue::ExcInfo>() };
@@ -1198,10 +1211,7 @@ impl Table {
             return exc_info.as_err();
         }
 
-        Ok(Table {
-            handle: handle,
-            exc_info: exc_info,
-        })
+        Ok(Table { handle, exc_info })
     }
 
     /// Get the number of rows in the table.
@@ -1335,7 +1345,7 @@ impl Table {
         dims: Option<&[u64]>,
         direct: bool,
         undefined: bool,
-    ) -> Result<(), Error> {
+    ) -> Result<(), TableError> {
         let cname = glue::StringBridge::from_rust(col_name);
         let comment = if let Some(comment_) = comment {
             comment_
@@ -1684,7 +1694,10 @@ impl Table {
     ///
     /// The underlying data type of the column must be scalar. Use this function
     /// wisely since some CASA tables may contain millions of rows.
-    pub fn get_col_as_vec<T: CasaScalarData>(&mut self, col_name: &str) -> Result<Vec<T>, Error> {
+    pub fn get_col_as_vec<T: CasaScalarData>(
+        &mut self,
+        col_name: &str,
+    ) -> Result<Vec<T>, TableError> {
         let ccol_name = glue::StringBridge::from_rust(col_name);
         let mut n_rows = 0;
         let mut data_type = glue::GlueDataType::TpOther;
@@ -1712,7 +1725,7 @@ impl Table {
         }
 
         if is_scalar == 0 || is_fixed_shape == 0 || n_dim != 0 {
-            return Err(NotScalarColumnError(data_type).into());
+            return Err(TableError::NotScalarColumnError(data_type).into());
         }
 
         if data_type != T::DATA_TYPE {
@@ -1759,7 +1772,7 @@ impl Table {
     }
 
     /// Get the value of one cell of the table.
-    pub fn get_cell<T: CasaDataType>(&mut self, col_name: &str, row: u64) -> Result<T, Error> {
+    pub fn get_cell<T: CasaDataType>(&mut self, col_name: &str, row: u64) -> Result<T, TableError> {
         let ccol_name = glue::StringBridge::from_rust(col_name);
         let mut data_type = glue::GlueDataType::TpOther;
         let mut n_dim = 0;
@@ -1786,7 +1799,8 @@ impl Table {
         }
 
         let result = if data_type != glue::GlueDataType::TpString {
-            let mut result = T::casatables_alloc(&dims[..n_dim as usize])?;
+            let mut result =
+                T::casatables_alloc(&dims[..n_dim as usize]).map_err(|e| TableError::from(e))?;
 
             let rv = unsafe {
                 glue::table_get_cell(
@@ -1835,7 +1849,7 @@ impl Table {
         &mut self,
         col_name: &str,
         row: u64,
-    ) -> Result<Vec<T>, Error> {
+    ) -> Result<Vec<T>, TableError> {
         let ccol_name = glue::StringBridge::from_rust(col_name);
         let mut data_type = glue::GlueDataType::TpOther;
         let mut n_dim = 0;
@@ -1997,10 +2011,7 @@ impl Table {
             return exc_info.as_err();
         }
 
-        Ok(TableRow {
-            handle: handle,
-            exc_info: exc_info,
-        })
+        Ok(TableRow { handle, exc_info })
     }
 
     /// Get an object for read-only access to individual rows of the table.
@@ -2025,7 +2036,7 @@ impl Table {
 
     /// Populate a [`TableRow`] accessor object with data from the specified
     /// row.
-    pub fn read_row(&mut self, row: &mut TableRow, row_number: u64) -> Result<(), Error> {
+    pub fn read_row(&mut self, row: &mut TableRow, row_number: u64) -> Result<(), TableError> {
         if unsafe { glue::table_row_read(row.handle, row_number, &mut row.exc_info) } != 0 {
             return row.exc_info.as_err();
         }
@@ -2034,9 +2045,9 @@ impl Table {
     }
 
     /// Perform `func` on each row of the table.
-    pub fn for_each_row<F>(&mut self, mut func: F) -> Result<(), Error>
+    pub fn for_each_row<F>(&mut self, mut func: F) -> Result<(), TableError>
     where
-        F: FnMut(&mut TableRow) -> Result<(), Error>,
+        F: FnMut(&mut TableRow) -> Result<(), TableError>,
     {
         let mut exc_info = unsafe { std::mem::zeroed::<glue::ExcInfo>() };
 
@@ -2045,10 +2056,7 @@ impl Table {
             return exc_info.as_err();
         }
 
-        let mut row = TableRow {
-            handle: handle,
-            exc_info: exc_info,
-        };
+        let mut row = TableRow { handle, exc_info };
 
         for row_number in 0..self.n_rows() {
             if unsafe { glue::table_row_read(row.handle, row_number as u64, &mut row.exc_info) }
@@ -2068,9 +2076,9 @@ impl Table {
         &mut self,
         row_range: std::ops::Range<u64>,
         mut func: F,
-    ) -> Result<(), Error>
+    ) -> Result<(), TableError>
     where
-        F: FnMut(&mut TableRow) -> Result<(), Error>,
+        F: FnMut(&mut TableRow) -> Result<(), TableError>,
     {
         let mut exc_info = unsafe { std::mem::zeroed::<glue::ExcInfo>() };
 
@@ -2098,9 +2106,9 @@ impl Table {
     }
 
     /// Perform `func` on each row indicated by `rows`.
-    pub fn for_each_specific_row<F>(&mut self, rows: &[u64], mut func: F) -> Result<(), Error>
+    pub fn for_each_specific_row<F>(&mut self, rows: &[u64], mut func: F) -> Result<(), TableError>
     where
-        F: FnMut(&mut TableRow) -> Result<(), Error>,
+        F: FnMut(&mut TableRow) -> Result<(), TableError>,
     {
         let mut exc_info = unsafe { std::mem::zeroed::<glue::ExcInfo>() };
 
@@ -2218,7 +2226,7 @@ pub struct TableRow {
 
 impl TableRow {
     /// Get the value of a specific cell in this row.
-    pub fn get_cell<T: CasaDataType>(&mut self, col_name: &str) -> Result<T, Error> {
+    pub fn get_cell<T: CasaDataType>(&mut self, col_name: &str) -> Result<T, TableError> {
         let ccol_name = glue::StringBridge::from_rust(col_name);
         let mut data_type = glue::GlueDataType::TpOther;
         let mut n_dim = 0;
@@ -2436,7 +2444,7 @@ impl TableRecord {
     /// This function will return an error if the underlying C++ code raises an
     /// exception. This *should* only happen if there is a memory allocation
     /// error.
-    pub fn new() -> Result<Self, Error> {
+    pub fn new() -> Result<Self, TableError> {
         let mut exc_info = unsafe { std::mem::zeroed::<glue::ExcInfo>() };
 
         let handle = unsafe { glue::tablerec_create(&mut exc_info) };
@@ -2500,7 +2508,7 @@ impl TableRecord {
     }
 
     /// Get the value of a particular field of this record.
-    pub fn get_field<T: CasaDataType>(&mut self, col_name: &str) -> Result<T, Error> {
+    pub fn get_field<T: CasaDataType>(&mut self, col_name: &str) -> Result<T, TableError> {
         let ccol_name = glue::StringBridge::from_rust(col_name);
         let mut data_type = glue::GlueDataType::TpOther;
         let mut n_dim = 0;
@@ -2691,7 +2699,7 @@ impl Debug for TableRecord {
 impl CasaDataType for TableRecord {
     const DATA_TYPE: glue::GlueDataType = glue::GlueDataType::TpRecord;
 
-    fn casatables_alloc(_shape: &[u64]) -> Result<Self, Error> {
+    fn casatables_alloc(_shape: &[u64]) -> Result<Self, TableError> {
         TableRecord::new()
     }
 
@@ -2807,7 +2815,7 @@ mod tests {
         // NewNoReplace should fail if table exists.
         assert!(matches!(
             Table::new(table_path, table_desc, 123, TableCreateMode::NewNoReplace),
-            Err(Error { .. })
+            Err(TableError::Casacore { .. })
         ));
     }
 

--- a/casatables/src/lib.rs
+++ b/casatables/src/lib.rs
@@ -37,7 +37,7 @@ use std::{
 };
 use thiserror::Error;
 
-pub use rubbl_core::{Array, Complex};
+pub use rubbl_core::{Array, Complex, CowArray};
 
 #[allow(missing_docs)]
 mod glue;

--- a/casatables_impl/Cargo.toml
+++ b/casatables_impl/Cargo.toml
@@ -15,4 +15,4 @@ A bundle of C++ code that can read the CASA table format for Rubbl.
 links = "casa"
 
 [build-dependencies]
-cc = { version = "1.0", features = ["parallel"] }
+cc = { version = "1.0.42", features = ["parallel"] }

--- a/casatables_impl/README.md
+++ b/casatables_impl/README.md
@@ -19,3 +19,11 @@ version of casacore.
 
 Note that this numbering scheme will break if casacore hits a version like
 3.1.10. We'll cross that bridge when we get there.
+
+## Crate Duplication
+
+See [the `rubbl_core` README on Crates.io][1] for a discussion of crate
+duplication issues that may arise with key dependencies such as [`ndarray`][2].
+
+[1]: https://crates.io/crates/rubbl_core/
+[2]: https://crates.io/crates/ndarray/

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,7 @@ Facade crate and CLI interface for the Rubbl astrophysics data analysis framewor
 rubbl_core = "thiscommit:2020-12-15:re8eeQu5"
 
 [dependencies]
-anyhow = "^1.0"
-clap = { version = "^4", features = ["cargo"] }
+anyhow = "1.0.0"
+clap = { version = "4.0.26", features = ["cargo"] }
 rubbl_core = { version ="0.0.0-dev.0", path = "../core" }
-thiserror = "^1.0"
+thiserror = "1.0.7"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,7 @@ Facade crate and CLI interface for the Rubbl astrophysics data analysis framewor
 rubbl_core = "thiscommit:2020-12-15:re8eeQu5"
 
 [dependencies]
+anyhow = "^1.0"
 clap = { version = "^4", features = ["cargo"] }
-failure = "^0.1"
-failure_derive = "^0.1"
 rubbl_core = { version ="0.0.0-dev.0", path = "../core" }
+thiserror = "^1.0"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,13 +10,9 @@ Heavily modeled on Cargo's implementation of the same sort of functionality.
 
 */
 
+use anyhow::Result;
 use clap::{crate_version, Arg, ArgMatches, Command};
-use failure::Error;
-use failure_derive::Fail;
-use rubbl_core::{
-    notify::{ClapNotificationArgsExt, NotificationBackend},
-    Result,
-};
+use rubbl_core::notify::{ClapNotificationArgsExt, NotificationBackend};
 use std::{
     collections::BTreeSet,
     env, fs,
@@ -27,8 +23,8 @@ use std::{
 
 // Some error help.
 
-#[derive(Fail, Debug)]
-#[fail(display = "no such sub-command `{}`", _0)]
+#[derive(thiserror::Error, Debug)]
+#[error("no such sub-command `{0}`")]
 pub struct NoSuchSubcommandError(String);
 
 fn main() {
@@ -125,7 +121,7 @@ fn do_external(cmd: &str, matches: &ArgMatches, _nbe: &mut dyn NotificationBacke
 
 /// Try to re-execute the process using the executable corresponding to the
 /// named sub-command. If this function returns, something went wrong.
-fn try_exec_subcommand(cmd: &str, args: &[&str]) -> Error {
+fn try_exec_subcommand(cmd: &str, args: &[&str]) -> anyhow::Error {
     let command_exe = format!("rubbl-{}{}", cmd, env::consts::EXE_SUFFIX);
     let path = search_directories()
         .iter()

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,11 +14,11 @@ Core types and traits for Rubbl, a Rust package for astrophysics.
 """
 
 [dependencies]
-anyhow = { version = "^1.0", features = ["backtrace"] }
-byteorder = "^1.4"
-clap = { version = "^4", features = ["cargo"] }
-ndarray = ">=0.8"
-num-complex = { version = ">=0.3" }
-approx = { version = ">=0.4", features = ["num-complex"] }
-termcolor = "^1.1"
-thiserror = "^1.0"
+anyhow = { version = "1.0.0", features = ["backtrace"] }
+byteorder = "1.4.0"
+clap = { version = "4.0.26", features = ["cargo"] }
+ndarray = "0.15.0"
+num-complex = "0.4.0"
+approx = { version = "0.5.0", features = ["num-complex"] }
+termcolor = "1.1.0"
+thiserror = "1.0.7"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Peter Williams <peter@newton.cx> and collaborators
+# Copyright 2017-2023 Peter Williams <peter@newton.cx> and collaborators
 # Licensed under the MIT License.
 
 [package]
@@ -14,14 +14,13 @@ Core types and traits for Rubbl, a Rust package for astrophysics.
 """
 
 [features]
-notifications = ["anyhow", "clap", "termcolor", "termcolor"]
+notifications = ["anyhow", "clap", "termcolor"]
 
 [dependencies]
+anyhow = { version = "1.0.0", features = ["backtrace"], optional = true }
 byteorder = "1.4.0"
+clap = { version = "4.0.26", features = ["cargo"], optional = true }
 ndarray = "0.15.0"
 num-complex = "0.4.0"
-thiserror = "1.0.7"
-
-anyhow = { version = "1.0.0", features = ["backtrace"], optional = true }
-clap = { version = "4.0.26", features = ["cargo"], optional = true }
 termcolor = { version = "1.1.0", optional = true }
+thiserror = "1.0.7"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,11 +14,11 @@ Core types and traits for Rubbl, a Rust package for astrophysics.
 """
 
 [dependencies]
+anyhow = { version = "^1.0", features = ["backtrace"] }
 byteorder = "^1.4"
 clap = { version = "^4", features = ["cargo"] }
-failure = "^0.1"
-failure_derive = "^0.1"
 ndarray = ">=0.8"
 num-complex = { version = ">=0.3" }
 approx = { version = ">=0.4", features = ["num-complex"] }
 termcolor = "^1.1"
+thiserror = "^1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,12 +13,15 @@ description = """
 Core types and traits for Rubbl, a Rust package for astrophysics.
 """
 
+[features]
+notifications = ["anyhow", "clap", "termcolor", "termcolor"]
+
 [dependencies]
-anyhow = { version = "1.0.0", features = ["backtrace"] }
 byteorder = "1.4.0"
-clap = { version = "4.0.26", features = ["cargo"] }
 ndarray = "0.15.0"
 num-complex = "0.4.0"
-approx = { version = "0.5.0", features = ["num-complex"] }
-termcolor = "1.1.0"
 thiserror = "1.0.7"
+
+anyhow = { version = "1.0.0", features = ["backtrace"], optional = true }
+clap = { version = "4.0.26", features = ["cargo"], optional = true }
+termcolor = { version = "1.1.0", optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,7 @@ notifications = ["anyhow", "clap", "termcolor"]
 anyhow = { version = "1.0.0", features = ["backtrace"], optional = true }
 byteorder = "1.4.0"
 clap = { version = "4.0.26", features = ["cargo"], optional = true }
-ndarray = "0.15.0"
-num-complex = "0.4.0"
+ndarray = "0.15.0"  # see README and src/lib.rs for discussion of constraints here; update when this changes
+num-complex = "0.4.0"  # ditto
 termcolor = { version = "1.1.0", optional = true }
 thiserror = "1.0.7"

--- a/core/README.md
+++ b/core/README.md
@@ -1,7 +1,46 @@
 # `rubbl_core`
 
-Core rubbl types:
+This crate defines some core types used by the Rubbl framework:
 
 - I/O helpers
 - Error handling
 - Numeric array types
+
+# Crate Duplication
+
+This crate depends on several foundational crates that your upstream project may
+also explicitly depend on:
+
+- [`anyhow`] 1.0 (optionally)
+- [`byteorder`] 1.4
+- [`clap`] 4.0 (optionally)
+- [`ndarray`] 0.15
+- [`num-complex`] 0.4
+- [`termcolor`] 1.1 (optionally)
+- [`thiserror`] 1.0
+
+[`anyhow`]: https://crates.io/crates/anyhow/
+[`byteorder`]: https://crates.io/crates/anyhow/
+[`clap`]: https://crates.io/crates/anyhow/
+[`ndarray`]: https://crates.io/crates/anyhow/
+[`num-complex`]: https://crates.io/crates/anyhow/
+[`termcolor`]: https://crates.io/crates/anyhow/
+[`thiserror`]: https://crates.io/crates/anyhow/
+
+If your project depends on a version of one of these crates that is not
+compatible with the version required by *this* crate, Cargo will include
+multiple versions of it in your build. These duplicates have the same name but
+cannot be intermixed. (Note that, according to [semver], versions `0.X` and
+`0.(X+1)` of a crate are *not* considered compatible.)
+
+Unfortunately, due to [limitations in Cargo's current resolver][1], this crate
+has to specify a narrow compatibility range for these dependencies. So, be
+careful to match your version requirements to the ones appropriate to the
+version of `rubbl_core` that you are using. The command [`cargo tree -d`][2]
+will display any duplicates in your dependency tree. If absolutely necessary,
+this crate re-exports some of its key dependencies, which can be used to “name”
+them in a reliable way even if they are duplicated elsewhere.
+
+[semver]: https://semver.org/
+[1]: https://github.com/rust-lang/cargo/issues/9029
+[2]: https://doc.rust-lang.org/cargo/commands/cargo-tree.html

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,7 +9,6 @@
 #![deny(missing_docs)]
 
 // convenience re-exports
-pub use failure::{Error, Fail, ResultExt};
 pub use ndarray::Array;
 pub use num_complex::Complex;
 
@@ -23,33 +22,6 @@ pub use num_complex::Complex;
 // let's just keep things simple.
 pub use approx;
 
-/// A “contextualized try” macro.
-///
-/// Attempts an operation that returns a Result and returns its Ok value if
-/// the operation is successful. If not, it returns an Err value of type
-/// `failure::Context` that includes explanatory text formatted using the
-/// `format!` macro and chains to the causative error. Example:
-///
-/// ```rust,ignore
-/// ctry!(write!(myfile, "hello"); "couldn\'t write to {}", myfile_path);
-/// ```
-///
-/// Note that the operation to be attempted and the arguments to `format!` are
-/// separated by a semicolon within the `ctry!()` parentheses.
-#[macro_export]
-macro_rules! ctry {
-    ($op:expr ; $( $chain_fmt_args:expr ),*) => {
-        {
-            use $crate::ResultExt;
-            $op.with_context(|_| format!($( $chain_fmt_args ),*))?
-        }
-    }
-}
-
 pub mod io;
 pub mod notify;
 pub mod num;
-
-/// A convenience Result type whose error half is fixed to be
-/// `failure::Error`.
-pub type Result<T> = ::std::result::Result<T, failure::Error>;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,7 +9,7 @@
 #![deny(missing_docs)]
 
 // convenience re-exports
-pub use ndarray::Array;
+pub use ndarray::{Array, CowArray};
 pub use num_complex::Complex;
 
 // `approx` isn't (as of October 2021) used anywhere in Rubbl, but by including

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 Peter Williams and collaborators
+// Copyright 2017-2023 Peter Williams and collaborators
 // Licensed under the MIT License.
 
 //! Core types and concepts of the Rubbl framework.
@@ -16,3 +16,63 @@ pub mod io;
 #[cfg(feature = "notifications")]
 pub mod notify;
 pub mod num;
+
+/// A “contextualized try” macro.
+///
+/// This macro is syntactic sugar. The expression
+///
+/// ```rust
+/// # use rubbl_core::ctry;
+/// # use anyhow::*;
+/// # fn myfun() -> Result<(), Error> {
+/// #   let op: Result<(), Error> = Ok(());
+/// #   let value = "something";
+/// ctry!(op; "spec: {}", value)
+/// #  ;
+/// #  Ok(())
+/// # }
+/// ```
+///
+/// is equivalent to:
+///
+/// ```rust
+/// # use anyhow::*;
+/// # fn myfun() -> Result<(), Error> {
+/// #   let op: Result<(), Error> = Ok(());
+/// #   let value = "something";
+/// {
+///     use anyhow::Context;
+///     op.with_context(|| format!("spec: {}", value))?
+/// }
+/// #   Ok(())
+/// # }
+/// ```
+///
+/// So, it attempts an operation that returns a [`Result`] (or [`Option`]) and
+/// evaluates to its [`Ok`] (or [`Some`]) value if the operation is successful.
+/// If not, it exits the current function with an [`Err`] value that has a
+/// formatted context string attached to it.
+///
+/// #### Example
+///
+/// ```rust
+/// # use anyhow::Error;
+/// # fn myfun() -> Result<(), Error> {
+/// use rubbl_core::ctry;
+/// use std::{fs::File, io::Write};
+///
+/// let path = "myfile.txt";
+/// let mut myfile = ctry!(File::open(path); "failed to open file `{}`", path);
+/// ctry!(write!(myfile, "hello"); "failed to write to file `{}`", path);
+/// # Ok(())
+/// # }
+/// ```
+#[macro_export]
+macro_rules! ctry {
+    ($op:expr ; $( $chain_fmt_args:expr ),*) => {
+        {
+            use anyhow::Context;
+            $op.with_context(|| format!($( $chain_fmt_args ),*))?
+        }
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,16 +12,7 @@
 pub use ndarray::{Array, CowArray};
 pub use num_complex::Complex;
 
-// `approx` isn't (as of October 2021) used anywhere in Rubbl, but by including
-// it as a dependency, we can get implementations of its traits for the Complex
-// type that we export. Re-exporting the crate gives users an ability to name
-// these traits if so desired.
-//
-// We could make this optional with a Cargo feature, for downstream users that
-// don't need the functionality, but it's a very lightweight dependency, so
-// let's just keep things simple.
-pub use approx;
-
 pub mod io;
+#[cfg(feature = "notifications")]
 pub mod notify;
 pub mod num;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,12 +5,29 @@
 //!
 //! This crate provides low-level types that are expected to be used throughout
 //! the Rubbl framework.
+//!
+//! # Crate Duplication and Re-Exports
+//!
+//! This crate depends on several foundational crates that your upstream project
+//! may also explicitly depend on, such as [`ndarray`]. If your project depends
+//! on a version of one of these crates that is not compatible with the version
+//! required by this crate, Cargo will build duplicated versions of these crates
+//! that, while they have the same name, cannot be intermixed. See [this crate’s
+//! Crates.io README][1] for a more detailed discussion.
+//!
+//! [1]: https://crates.io/crates/rubbl_core/
+//!
+//! If you are in a situation where you can't avoid this duplication, this crate
+//! re-exports some of its dependencies, providing a way to reliably name the specific
+//! version that it’s referencing.
 
 #![deny(missing_docs)]
 
-// convenience re-exports
-pub use ndarray::{Array, CowArray};
-pub use num_complex::Complex;
+// convenience re-exports; these can help consumers make sure they're referencing the
+// same types if a crate gets duplicated. See also the README.
+pub use anyhow;
+pub use ndarray::{self, Array, CowArray};
+pub use num_complex::{self, Complex};
 
 pub mod io;
 #[cfg(feature = "notifications")]

--- a/core/src/notify/mod.rs
+++ b/core/src/notify/mod.rs
@@ -17,8 +17,8 @@ engine. (Which the author of this module also wrote.)
 #[macro_use]
 pub mod termcolor;
 
+use anyhow::Error;
 use clap;
-use failure::Error;
 use std::cmp;
 use std::fmt::Arguments;
 use std::result::Result as StdResult;
@@ -201,9 +201,9 @@ impl BufferingNotificationBackend {
 impl NotificationBackend for BufferingNotificationBackend {
     fn notify(&mut self, kind: NotificationKind, args: Arguments, err: Option<Error>) {
         self.buf.push(NotificationData {
-            kind: kind,
+            kind,
             text: format!("{}", args),
-            err: err,
+            err,
         });
     }
 }

--- a/core/src/notify/termcolor.rs
+++ b/core/src/notify/termcolor.rs
@@ -13,7 +13,7 @@ engine. (Which the author of this module also wrote.)
 // TODO: make this module a feature that can be disabled if the user doesn't want to
 // link with termcolor
 
-use failure::Error;
+use anyhow::Error;
 use std::fmt::Arguments;
 use std::io::Write;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
@@ -55,14 +55,14 @@ impl TermcolorNotificationBackend {
         fatal_spec.set_fg(Some(Color::Red)).set_bold(true);
 
         TermcolorNotificationBackend {
-            chatter: chatter,
+            chatter,
             stdout: StandardStream::stdout(ColorChoice::Auto),
             stderr: StandardStream::stderr(ColorChoice::Auto),
-            note_spec: note_spec,
+            note_spec,
             //highlight_spec: highlight_spec,
-            warning_spec: warning_spec,
-            severe_spec: severe_spec,
-            fatal_spec: fatal_spec,
+            warning_spec,
+            severe_spec,
+            fatal_spec,
         }
     }
 
@@ -135,7 +135,7 @@ impl TermcolorNotificationBackend {
         let mut prefix = "error:";
         let err = err.into();
 
-        for fail in err.iter_chain() {
+        for fail in err.chain() {
             self.generic_message(
                 NotificationKind::Severe,
                 Some(prefix),
@@ -161,7 +161,7 @@ impl NotificationBackend for TermcolorNotificationBackend {
         self.generic_message(kind, None, args);
 
         if let Some(e) = err {
-            for fail in e.iter_chain() {
+            for fail in e.chain() {
                 self.generic_message(kind, Some("caused by:"), format_args!("{}", fail));
             }
 

--- a/core/src/num.rs
+++ b/core/src/num.rs
@@ -3,16 +3,13 @@
 
 //! General helpers for numerics.
 
-use failure_derive::Fail;
 use ndarray::{IntoDimension, Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6};
+use thiserror::Error;
 
 /// An error type used when two arrays should have the same dimensionality,
 /// but do not.
-#[derive(Fail, Debug)]
-#[fail(
-    display = "Expected a {}-dimensional array, but got one with {} dimensions",
-    expected, actual
-)]
+#[derive(Error, Debug)]
+#[error("Expected a {expected}-dimensional array, but got one with {actual} dimensions")]
 pub struct DimensionMismatchError {
     /// The number of dimensions that the array was expected to have.
     pub expected: usize,

--- a/fits/Cargo.toml
+++ b/fits/Cargo.toml
@@ -18,10 +18,10 @@ rubbl_core = "thiscommit:2020-12-15:peif3Eng"
 rubbl_visdata = "thiscommit:2020-12-15:Ox8roFai"
 
 [dependencies]
-failure = "^0.1"
-failure_derive = "^0.1"
 rubbl_core = { path = "../core", version ="0.0.0-dev.0"}
 rubbl_visdata = { path = "../visdata", version ="0.0.0-dev.0"}
+thiserror = "^1.0"
 
 [dev-dependencies]
+anyhow = "^1.0"
 clap = { version = "^4", features = ["cargo"] }

--- a/fits/Cargo.toml
+++ b/fits/Cargo.toml
@@ -20,8 +20,8 @@ rubbl_visdata = "thiscommit:2020-12-15:Ox8roFai"
 [dependencies]
 rubbl_core = { path = "../core", version ="0.0.0-dev.0"}
 rubbl_visdata = { path = "../visdata", version ="0.0.0-dev.0"}
-thiserror = "^1.0"
+thiserror = "1.0.7"
 
 [dev-dependencies]
-anyhow = "^1.0"
-clap = { version = "^4", features = ["cargo"] }
+anyhow = "1.0.0"
+clap = { version = "4.0.26", features = ["cargo"] }

--- a/fits/README.md
+++ b/fits/README.md
@@ -1,3 +1,9 @@
 # `rubbl_fits`
 
 The Rubbl FITS I/O library.
+
+See [the `rubbl_core` README on Crates.io][1] for a discussion of crate
+duplication issues that may arise with key dependencies such as [`ndarray`][2].
+
+[1]: https://crates.io/crates/rubbl_core/
+[2]: https://crates.io/crates/ndarray/

--- a/fits/examples/fitsdump.rs
+++ b/fits/examples/fitsdump.rs
@@ -30,7 +30,9 @@ fn main() {
 
         Err(e) => {
             println!("fatal error while processing {}", path.to_string_lossy());
-            println!("  caused by: {}", e);
+            for cause in e.chain() {
+                println!("  caused by: {}", cause);
+            }
             1
         }
     });

--- a/fits/examples/fitsdump.rs
+++ b/fits/examples/fitsdump.rs
@@ -39,13 +39,13 @@ fn main() {
 }
 
 fn inner(path: &OsStr) -> Result<i32, anyhow::Error> {
-    let file = fs::File::open(path).with_context(|| "error opening file")?;
+    let file = fs::File::open(path).context("error opening file")?;
     let mut dec = rubbl_fits::FitsDecoder::new(AligningReader::new(file));
     let t0 = Instant::now();
     let mut last_was_data = false;
 
     loop {
-        match dec.next().with_context(|| "error parsing FITS")? {
+        match dec.next().context("error parsing FITS")? {
             None => {
                 break;
             }

--- a/fits/examples/fitssummary.rs
+++ b/fits/examples/fitssummary.rs
@@ -3,8 +3,8 @@
 //! which doesn't seek but therefore has to actually read through all of the
 //! data.
 
+use anyhow::Context;
 use clap::{Arg, Command};
-use failure::{Error, ResultExt};
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::process;
@@ -28,16 +28,14 @@ fn main() {
 
         Err(e) => {
             println!("fatal error while processing {}", path.to_string_lossy());
-            for cause in e.iter_chain() {
-                println!("  caused by: {}", cause);
-            }
+            println!("  caused by: {}", e);
             1
         }
     });
 }
 
-fn inner(path: &OsStr) -> Result<i32, Error> {
-    let file = fs::File::open(path).context("error opening file")?;
+fn inner(path: &OsStr) -> Result<i32, anyhow::Error> {
+    let file = fs::File::open(path).with_context(|| "error opening file")?;
     let fits = rubbl_fits::FitsParser::new(file)?;
 
     for (num, hdu) in fits.hdus().iter().enumerate() {

--- a/fits/examples/fitssummary.rs
+++ b/fits/examples/fitssummary.rs
@@ -28,7 +28,9 @@ fn main() {
 
         Err(e) => {
             println!("fatal error while processing {}", path.to_string_lossy());
-            println!("  caused by: {}", e);
+            for cause in e.chain() {
+                println!("  caused by: {}", cause);
+            }
             1
         }
     });

--- a/fits/examples/fitssummary.rs
+++ b/fits/examples/fitssummary.rs
@@ -37,7 +37,7 @@ fn main() {
 }
 
 fn inner(path: &OsStr) -> Result<i32, anyhow::Error> {
-    let file = fs::File::open(path).with_context(|| "error opening file")?;
+    let file = fs::File::open(path).context("error opening file")?;
     let fits = rubbl_fits::FitsParser::new(file)?;
 
     for (num, hdu) in fits.hdus().iter().enumerate() {

--- a/fits/src/lib.rs
+++ b/fits/src/lib.rs
@@ -8,24 +8,109 @@
 
 #![deny(missing_docs)]
 
-use failure::Error;
-use failure_derive::Fail;
 use rubbl_core::io::EofReadExactExt;
 use std::io::prelude::*;
 use std::io::SeekFrom;
 use std::str;
-
-// Define this before any submodules are parsed.
-macro_rules! fitserr {
-    ($( $fmt_args:expr ),*) => {
-        Err($crate::FitsFormatError(format!($( $fmt_args ),*)).into())
-    }
-}
+use thiserror::Error;
 
 /// An error type for when a FITS file is malformed.
-#[derive(Debug, Fail)]
-#[fail(display = "{}", _0)]
-pub struct FitsFormatError(String);
+#[allow(missing_docs)]
+#[derive(Debug, Error)]
+pub enum FitsError {
+    #[error("FITS stream should be a multiple of 2880 bytes long; got {0}")]
+    Not2880Multiple(u64),
+
+    #[error("file does not appear to be in FITS format")]
+    InvalidFormat,
+
+    #[error("second FITS header must be BITPIX")]
+    SecondHeaderNotBitpix,
+
+    #[error("unsupported BITPIX value in FITS file: {0}")]
+    UnsupportedBitpix(isize),
+
+    #[error("third FITS header must be NAXIS")]
+    ThirdHeaderNotNaxis,
+
+    #[error("unsupported NAXIS value in FITS file: {0}")]
+    BadNaxisValue(isize),
+
+    #[error("illegal negative FITS GCOUNT value")]
+    NegativeGcountValue,
+
+    #[error("illegal extension HDU without EXTNAME header")]
+    ExtHduWithoutExtname,
+
+    #[error("illegal negative FITS group size")]
+    NegativeGroupSize,
+
+    #[error("truncated-looking FITS file")]
+    Truncated,
+
+    #[error("FITS data stream does not begin with \"SIMPLE = T\" marker")]
+    NotSimple,
+
+    #[error("illegal header keyword ASCII code {0}")]
+    BadHeaderAscii(u8),
+
+    #[error("malformed FITS header keyword")]
+    MalformedHeader,
+
+    #[error("{0}")]
+    FitsFormat(#[from] FitsFormatError),
+
+    #[error("{0}")]
+    IO(#[from] std::io::Error),
+}
+
+/// An error type associated with problems that might occur when reading a FITS
+/// file.
+#[allow(missing_docs)]
+#[derive(Debug, Error)]
+pub enum FitsFormatError {
+    #[error("expected opening equals and quote in fixed-format string record")]
+    UnexpectedStrSep,
+
+    #[error("illegal non-printable-ASCII value in fixed-format string record")]
+    IllegalAscii,
+
+    #[error("illegal ASCII value {0} after string in fixed-format string record")]
+    IllegalAsciiAfterString(u8),
+
+    #[error("illegal ASCII value {0} after single quote in fixed-format string record")]
+    IllegalAsciiAfterQuote(u8),
+
+    #[error("illegal unterminated fixed-format string record")]
+    Unterminated,
+
+    #[error("expected space or slash in byte 30 of fixed-format integer record")]
+    UnexpectedByte30,
+
+    #[error("empty record that should have been a fixed-format integer")]
+    EmptyRecordInt,
+
+    #[error("expected digit but got ASCII {0:?} in fixed-format integer")]
+    ExpectedDigit(u8),
+
+    #[error("malformed FITS NAXIS header")]
+    MalformedNaxis,
+
+    #[error("expected digit but got ASCII {0:?} in NAXIS header")]
+    ExpectedDigitNaxisHeader(u8),
+
+    #[error("expected space but got ASCII {0:?} in NAXIS header")]
+    ExpectedSpaceNaxisHeader(u8),
+
+    #[error("misnumbered NAXIS header (expected {expected}, got {got})")]
+    MisnumberedNaxis { expected: usize, got: usize },
+
+    #[error("illegal negative NAXIS{value} value {n}")]
+    NegativeNaxisValue { value: usize, n: isize },
+
+    #[error("{0}")]
+    Utf8(#[from] std::str::Utf8Error),
+}
 
 /// A chunk of FITS file data, as produced by our low-level decoder.
 #[derive(Clone, Debug)]
@@ -144,7 +229,7 @@ impl<R: Read> FitsDecoder<R> {
     /// Create a new decoder that gets data from the Read type passed as an argument.
     pub fn new(inner: R) -> Self {
         Self {
-            inner: inner,
+            inner,
             buf: [0; 2880],
             offset: 2880,
             state: DecoderState::Beginning,
@@ -161,12 +246,12 @@ impl<R: Read> FitsDecoder<R> {
     /// Get the next item in the FITS stream.
     ///
     /// Returns Ok(None) at an expected EOF.
-    pub fn next<'a>(&'a mut self) -> Result<Option<LowLevelFitsItem<'a>>, Error> {
+    pub fn next<'a>(&'a mut self) -> Result<Option<LowLevelFitsItem<'a>>, FitsError> {
         if self.offset == 2880 {
-            if !self.inner.eof_read_exact::<Error>(&mut self.buf)? {
+            if !self.inner.eof_read_exact::<FitsError>(&mut self.buf)? {
                 if self.state != DecoderState::NewHdu && self.state != DecoderState::SpecialRecords
                 {
-                    return fitserr!("truncated-looking FITS file");
+                    return Err(FitsError::Truncated);
                 }
 
                 return Ok(None);
@@ -204,7 +289,7 @@ impl<R: Read> FitsDecoder<R> {
 
         if self.state == DecoderState::Beginning {
             if &record[..FITS_MARKER.len()] != FITS_MARKER {
-                return fitserr!("FITS data stream does not begin with \"SIMPLE = T\" marker");
+                return Err(FitsError::NotSimple);
             }
 
             self.state = DecoderState::SizingHeaders;
@@ -240,14 +325,14 @@ impl<R: Read> FitsDecoder<R> {
                     -32 => Bitpix::F32,
                     -64 => Bitpix::F64,
                     other => {
-                        return fitserr!("unsupported BITPIX value in FITS file: {}", other);
+                        return Err(FitsError::UnsupportedBitpix(other));
                     }
                 };
             } else if &record[..NAXIS_MARKER.len()] == NAXIS_MARKER {
                 let naxis = parse_fixed_int(record)?;
 
                 if naxis < 0 || naxis > 999 {
-                    return fitserr!("unsupported NAXIS value in FITS file: {}", naxis);
+                    return Err(FitsError::BadNaxisValue(naxis));
                 }
 
                 self.naxis.clear();
@@ -273,7 +358,7 @@ impl<R: Read> FitsDecoder<R> {
                 let n = parse_fixed_int(record)?;
 
                 if n < 0 {
-                    return fitserr!("illegal negative FITS GCOUNT value");
+                    return Err(FitsError::NegativeGcountValue);
                 }
 
                 self.gcount = n as usize;
@@ -285,7 +370,7 @@ impl<R: Read> FitsDecoder<R> {
                 };
 
                 if group_size < 0 {
-                    return fitserr!("illegal negative FITS group size");
+                    return Err(FitsError::NegativeGroupSize);
                 }
 
                 self.offset = 2880;
@@ -318,7 +403,7 @@ impl<R: Read> FitsDecoder<R> {
                         break;
                     }
                     other => {
-                        return fitserr!("illegal header keyword ASCII code {}", other);
+                        return Err(FitsError::BadHeaderAscii(other));
                     }
                 }
 
@@ -327,7 +412,7 @@ impl<R: Read> FitsDecoder<R> {
 
             while i < 8 {
                 if record[i] != b' ' {
-                    return fitserr!("malformed FITS header keyword");
+                    return Err(FitsError::MalformedHeader);
                 }
 
                 i += 1;
@@ -407,14 +492,11 @@ pub struct ParsedHdu {
 
 impl<R: Read + Seek> FitsParser<R> {
     /// Parse the headers of a FITS file.
-    pub fn new(mut inner: R) -> Result<Self, Error> {
+    pub fn new(mut inner: R) -> Result<Self, FitsError> {
         let file_size = inner.seek(SeekFrom::End(0))?;
 
         if file_size % 2880 != 0 {
-            return fitserr!(
-                "FITS stream should be a multiple of 2880 bytes long; got {}",
-                file_size
-            );
+            return Err(FitsError::Not2880Multiple(file_size));
         }
 
         inner.seek(SeekFrom::Start(0))?;
@@ -445,7 +527,7 @@ impl<R: Read + Seek> FitsParser<R> {
 
             if hdus.len() == 0 {
                 if &buf[..FITS_MARKER.len()] != FITS_MARKER {
-                    return fitserr!("file does not appear to be in FITS format");
+                    return Err(FitsError::InvalidFormat);
                 }
             } else {
                 if &buf[..XTENSION_MARKER.len()] != XTENSION_MARKER {
@@ -469,7 +551,7 @@ impl<R: Read + Seek> FitsParser<R> {
                 let record = &buf[80..160];
 
                 if &record[..BITPIX_MARKER.len()] != BITPIX_MARKER {
-                    return fitserr!("second FITS header must be BITPIX");
+                    return Err(FitsError::SecondHeaderNotBitpix);
                 }
 
                 parse_fixed_int(record)?
@@ -483,7 +565,7 @@ impl<R: Read + Seek> FitsParser<R> {
                 -32 => Bitpix::F32,
                 -64 => Bitpix::F64,
                 other => {
-                    return fitserr!("unsupported BITPIX value in FITS file: {}", other);
+                    return Err(FitsError::UnsupportedBitpix(other));
                 }
             };
 
@@ -495,14 +577,14 @@ impl<R: Read + Seek> FitsParser<R> {
                 let record = &buf[160..240];
 
                 if &record[..NAXIS_MARKER.len()] != NAXIS_MARKER {
-                    return fitserr!("third FITS header must be NAXIS");
+                    return Err(FitsError::ThirdHeaderNotNaxis);
                 }
 
                 parse_fixed_int(record)?
             };
 
             if naxis_value < 0 || naxis_value > 999 {
-                return fitserr!("unsupported NAXIS value in FITS file: {}", naxis_value);
+                return Err(FitsError::BadNaxisValue(naxis_value));
             }
 
             naxis.reserve(naxis_value as usize);
@@ -535,7 +617,7 @@ impl<R: Read + Seek> FitsParser<R> {
                     let n = parse_fixed_int(record)?;
 
                     if n < 0 {
-                        return fitserr!("illegal negative FITS GCOUNT value");
+                        return Err(FitsError::NegativeGcountValue);
                     }
 
                     gcount = n as usize;
@@ -557,7 +639,7 @@ impl<R: Read + Seek> FitsParser<R> {
                 match extname {
                     Some(s) => s,
                     None => {
-                        return fitserr!("illegal extension HDU without EXTNAME header");
+                        return Err(FitsError::ExtHduWithoutExtname);
                     }
                 }
             };
@@ -569,7 +651,7 @@ impl<R: Read + Seek> FitsParser<R> {
             let group_size = pcount + naxis.iter().fold(1, |p, n| p * n) as isize;
 
             if group_size < 0 {
-                return fitserr!("illegal negative FITS group size");
+                return Err(FitsError::NegativeGroupSize);
             }
 
             let data_size = bitpix.n_bytes() * gcount * group_size as usize;
@@ -650,9 +732,9 @@ impl ParsedHdu {
     }
 }
 
-fn parse_fixed_int(record: &[u8]) -> Result<isize, Error> {
+fn parse_fixed_int(record: &[u8]) -> Result<isize, FitsFormatError> {
     if record[30] != b' ' && record[30] != b'/' {
-        return fitserr!("expected space or slash in byte 30 of fixed-format integer record");
+        return Err(FitsFormatError::UnexpectedByte30);
     }
 
     let mut i = 10;
@@ -666,7 +748,7 @@ fn parse_fixed_int(record: &[u8]) -> Result<isize, Error> {
     }
 
     if i == 30 {
-        return fitserr!("empty record that should have been a fixed-format integer");
+        return Err(FitsFormatError::EmptyRecordInt);
     }
 
     let mut negate = false;
@@ -679,7 +761,7 @@ fn parse_fixed_int(record: &[u8]) -> Result<isize, Error> {
     }
 
     if i == 30 {
-        return fitserr!("empty record that should have been a fixed-format integer");
+        return Err(FitsFormatError::EmptyRecordInt);
     }
 
     let mut value = 0;
@@ -717,10 +799,7 @@ fn parse_fixed_int(record: &[u8]) -> Result<isize, Error> {
                 value += 9;
             }
             other => {
-                return fitserr!(
-                    "expected digit but got ASCII {:?} in fixed-format integer",
-                    other
-                );
+                return Err(FitsFormatError::ExpectedDigit(other));
             }
         }
 
@@ -763,9 +842,9 @@ fn fixed_int_parsing() {
     assert!(parse_fixed_int(r).is_err());
 }
 
-fn parse_fixed_string(record: &[u8]) -> Result<String, Error> {
+fn parse_fixed_string(record: &[u8]) -> Result<String, FitsFormatError> {
     if &record[8..11] != b"= '" {
-        return fitserr!("expected opening equals and quote in fixed-format string record");
+        return Err(FitsFormatError::UnexpectedStrSep);
     }
 
     let mut buf = [0u8; 69];
@@ -788,7 +867,7 @@ fn parse_fixed_string(record: &[u8]) -> Result<String, Error> {
         let c = record[i + 11];
 
         if c < 0x20 || c > 0x7E {
-            return fitserr!("illegal non-printable-ASCII value in fixed-format string record");
+            return Err(FitsFormatError::IllegalAscii);
         }
 
         match state {
@@ -825,11 +904,7 @@ fn parse_fixed_string(record: &[u8]) -> Result<String, Error> {
                 }
 
                 other => {
-                    return fitserr!(
-                        "illegal ASCII value {} after single quote in \
-                         fixed-format string record",
-                        other
-                    );
+                    return Err(FitsFormatError::IllegalAsciiAfterQuote(other));
                 }
             },
 
@@ -841,11 +916,7 @@ fn parse_fixed_string(record: &[u8]) -> Result<String, Error> {
                 }
 
                 other => {
-                    return fitserr!(
-                        "illegal ASCII value {} after string in \
-                         fixed-format string record",
-                        other
-                    );
+                    return Err(FitsFormatError::IllegalAsciiAfterString(other));
                 }
             },
 
@@ -856,7 +927,7 @@ fn parse_fixed_string(record: &[u8]) -> Result<String, Error> {
     }
 
     if state == State::Chars {
-        return fitserr!("illegal unterminated fixed-format string record");
+        return Err(FitsFormatError::Unterminated);
     }
 
     Ok(if !any_chars {
@@ -900,13 +971,13 @@ fn fixed_string_parsing() {
 /// Returns Ok(true) if this record in question was the appropriate NAXISnnn
 /// header; Ok(false) if it was some other valid-looking header; Err(_) if it
 /// looks like it should have been a NAXIS header but something went wrong.
-fn accumulate_naxis_value(record: &[u8], naxis: &mut Vec<usize>) -> Result<bool, Error> {
+fn accumulate_naxis_value(record: &[u8], naxis: &mut Vec<usize>) -> Result<bool, FitsFormatError> {
     if &record[..5] != b"NAXIS" {
         return Ok(false); // Th
     }
 
     if &record[8..10] != b"= " {
-        return fitserr!("malformed FITS NAXIS header");
+        return Err(FitsFormatError::MalformedNaxis);
     }
 
     let mut value = 0;
@@ -949,7 +1020,7 @@ fn accumulate_naxis_value(record: &[u8], naxis: &mut Vec<usize>) -> Result<bool,
                 value += 9;
             }
             other => {
-                return fitserr!("expected digit but got ASCII {:?} in NAXIS header", other);
+                return Err(FitsFormatError::ExpectedDigitNaxisHeader(other));
             }
         }
 
@@ -958,27 +1029,23 @@ fn accumulate_naxis_value(record: &[u8], naxis: &mut Vec<usize>) -> Result<bool,
 
     while i < 8 {
         if record[i] != b' ' {
-            return fitserr!(
-                "expected space but got ASCII {:?} in NAXIS header",
-                record[i]
-            );
+            return Err(FitsFormatError::ExpectedSpaceNaxisHeader(record[i]));
         }
 
         i += 1;
     }
 
     if value != naxis.len() + 1 {
-        return fitserr!(
-            "misnumbered NAXIS header (expected {}, got {})",
-            naxis.len() + 1,
-            value
-        );
+        return Err(FitsFormatError::MisnumberedNaxis {
+            expected: naxis.len() + 1,
+            got: value,
+        });
     }
 
     let n = parse_fixed_int(record)?;
 
     if n < 0 {
-        return fitserr!("illegal negative NAXIS{} value {}", value, n);
+        return Err(FitsFormatError::NegativeNaxisValue { value, n });
     }
 
     naxis.push(n as usize);

--- a/miriad/Cargo.toml
+++ b/miriad/Cargo.toml
@@ -21,12 +21,12 @@ rubbl_visdata = "thiscommit:2020-12-15:Rohw0kei"
 
 [dependencies]
 byteorder = "^1.4"
-failure = "^0.1"
-failure_derive = "^0.1"
 openat = "^0.1.21"
 rubbl_core = { path = "../core", version ="0.0.0-dev.0"}
 rubbl_visdata = { path = "../visdata", version ="0.0.0-dev.0"}
+thiserror = "^1.0"
 
 [dev-dependencies]
+anyhow = "^1.0"
 clap = { version = "^4", features = ["cargo"] }
 pbr = "^1.0"

--- a/miriad/Cargo.toml
+++ b/miriad/Cargo.toml
@@ -20,13 +20,13 @@ rubbl_core = "thiscommit:2020-12-15:aishi6Ae"
 rubbl_visdata = "thiscommit:2020-12-15:Rohw0kei"
 
 [dependencies]
-byteorder = "^1.4"
-openat = "^0.1.21"
+byteorder = "1.4.0"
+openat = "0.1.7"
 rubbl_core = { path = "../core", version ="0.0.0-dev.0"}
 rubbl_visdata = { path = "../visdata", version ="0.0.0-dev.0"}
-thiserror = "^1.0"
+thiserror = "1.0.7"
 
 [dev-dependencies]
-anyhow = "^1.0"
-clap = { version = "^4", features = ["cargo"] }
-pbr = "^1.0"
+anyhow = "1.0.0"
+clap = { version = "4.0.26", features = ["cargo"] }
+pbr = "1.0.0"

--- a/miriad/README.md
+++ b/miriad/README.md
@@ -1,3 +1,9 @@
 # `rubbl_miriad`
 
 The Rubbl library for I/O on Miriad datasets.
+
+See [the `rubbl_core` README on Crates.io][1] for a discussion of crate
+duplication issues that may arise with key dependencies such as [`ndarray`][2].
+
+[1]: https://crates.io/crates/rubbl_core/
+[2]: https://crates.io/crates/ndarray/

--- a/miriad/examples/hera352.rs
+++ b/miriad/examples/hera352.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{bail, Context, Error};
 use clap::{Arg, Command};
+use rubbl_core::ctry;
 use rubbl_miriad::mask::{MaskDecoder, MaskEncoder};
 use rubbl_miriad::visdata::{
     decode_baseline, encode_baseline, Decoder, Encoder, UvVariableReference,
@@ -511,9 +512,10 @@ impl UvInflator {
                     conj = true;
                 }
 
-                let rec = self.records.get(&(src_mir_1, src_mir_2)).with_context(|| {
-                    format!("missing data for source {src_mir_1}-{src_mir_2} baseline")
-                })?;
+                let rec = ctry!(
+                    self.records.get(&(src_mir_1, src_mir_2));
+                    "missing data for source {src_mir_1}-{src_mir_2} baseline"
+                );
 
                 if rec.update_time != time {
                     bail!(

--- a/miriad/examples/hera352.rs
+++ b/miriad/examples/hera352.rs
@@ -117,7 +117,7 @@ impl UvInflator {
         let out_mib = inst.out_uv.flush(&mut inst.out_ds)? as f64 / (1024. * 1024.);
         inst.out_ds
             .flush()
-            .with_context(|| "couldn't flush changes to output dataset")?;
+            .context("couldn't flush changes to output dataset")?;
 
         let dur = t0.elapsed();
         let dur_secs = dur.subsec_nanos() as f64 * 1e-9 + dur.as_secs() as f64;
@@ -140,22 +140,22 @@ impl UvInflator {
     }
 
     fn new(in_path: &OsStr, out_path: &OsStr) -> Result<Self, Error> {
-        let mut in_ds = DataSet::open(in_path).with_context(|| "error opening input dataset")?;
+        let mut in_ds = DataSet::open(in_path).context("error opening input dataset")?;
         let mut in_uv = in_ds
             .open_uv()
-            .with_context(|| "could not open input as UV dataset")?;
+            .context("could not open input as UV dataset")?;
         let mut in_flags = MaskDecoder::new(
             in_ds
                 .get("flags")?
-                .with_context(|| "no \"flags\" item in input")?
+                .context("no \"flags\" item in input")?
                 .into_byte_stream()?,
         );
 
-        let mut out_ds = rubbl_miriad::DataSet::open(out_path)
-            .with_context(|| "error opening output dataset")?;
+        let mut out_ds =
+            rubbl_miriad::DataSet::open(out_path).context("error opening output dataset")?;
         let mut out_uv = out_ds
             .new_uv_like(&in_uv)
-            .with_context(|| "could not open output for writing UV data")?;
+            .context("could not open output for writing UV data")?;
         let out_flags = MaskEncoder::new(out_ds.create_large_item("flags", Type::Int32)?);
 
         // Progress bar
@@ -168,7 +168,7 @@ impl UvInflator {
         // nbls, nblts, st_type. We *should* skip pol here too, but we're
         // leveraging the fact that we know our datasets are single-pol.
 
-        in_uv.next().with_context(|| "could not read UV data")?;
+        in_uv.next().context("could not read UV data")?;
 
         for var in in_uv.variables() {
             match var.name() {
@@ -181,7 +181,7 @@ impl UvInflator {
 
             out_uv
                 .write_var(var)
-                .with_context(|| "could not write UV variable")?;
+                .context("could not write UV variable")?;
         }
 
         // antnums is an (in_nants)-element f64 array mapping HERA antenna numbers
@@ -196,7 +196,7 @@ impl UvInflator {
         in_uv.get_data(
             in_uv
                 .lookup_variable("antnums")
-                .with_context(|| format!("no \"antnums\" UV variable"))?,
+                .context("no \"antnums\" UV variable")?,
             &mut antnums_float,
         );
 
@@ -210,7 +210,7 @@ impl UvInflator {
         let in_nants_slots = in_uv.get_scalar::<i32>(
             in_uv
                 .lookup_variable("nants")
-                .with_context(|| "no \"nants\" UV variable")?,
+                .context("no \"nants\" UV variable")?,
         ) as usize;
         let mut last_used_antnum = 0; // assuming antnum 0 is always taken
 
@@ -262,7 +262,7 @@ impl UvInflator {
         let in_antnames: String = in_uv.get_scalar(
             in_uv
                 .lookup_variable("antnames")
-                .with_context(|| "no \"antnames\" UV variable")?,
+                .context("no \"antnames\" UV variable")?,
         );
         let in_antnames = in_antnames.split_at(in_antnames.len() - 2).0.split_at(1).1;
         let mut out_antnames = String::from("[");
@@ -291,7 +291,7 @@ impl UvInflator {
         in_uv.get_data(
             in_uv
                 .lookup_variable("antpos")
-                .with_context(|| "no \"antpos\" UV variable")?,
+                .context("no \"antpos\" UV variable")?,
             &mut in_antpos,
         );
 
@@ -321,7 +321,7 @@ impl UvInflator {
         let ntimes: i32 = in_uv.get_scalar(
             in_uv
                 .lookup_variable("ntimes")
-                .with_context(|| "no \"ntimes\" UV variable")?,
+                .context("no \"ntimes\" UV variable")?,
         );
         out_uv.write_scalar("nblts", nbls * ntimes)?;
 
@@ -330,7 +330,7 @@ impl UvInflator {
         let in_st_type: String = in_uv.get_scalar(
             in_uv
                 .lookup_variable("st_type")
-                .with_context(|| "no \"st_type\" UV variable")?,
+                .context("no \"st_type\" UV variable")?,
         );
         let in_st_type = in_st_type.split_at(in_st_type.len() - 2).0.split_at(1).1;
         let st_types: Vec<_> = in_st_type.split(", ").collect();
@@ -355,27 +355,27 @@ impl UvInflator {
         let nschan: usize = in_uv.get_scalar::<i32>(
             in_uv
                 .lookup_variable("nschan")
-                .with_context(|| "no \"nschan\" UV variable")?,
+                .context("no \"nschan\" UV variable")?,
         ) as usize;
 
         let time_var = in_uv
             .lookup_variable("time")
-            .with_context(|| "no \"time\" UV variable")?;
+            .context("no \"time\" UV variable")?;
         let lst_var = in_uv
             .lookup_variable("lst")
-            .with_context(|| "no \"lst\" UV variable")?;
+            .context("no \"lst\" UV variable")?;
         let ra_var = in_uv
             .lookup_variable("ra")
-            .with_context(|| "no \"ra\" UV variable")?;
+            .context("no \"ra\" UV variable")?;
         let baseline_var = in_uv
             .lookup_variable("baseline")
-            .with_context(|| "no \"baseline\" UV variable")?;
+            .context("no \"baseline\" UV variable")?;
         let coord_var = in_uv
             .lookup_variable("coord")
-            .with_context(|| "no \"coord\" UV variable")?;
+            .context("no \"coord\" UV variable")?;
         let corr_var = in_uv
             .lookup_variable("corr")
-            .with_context(|| "no \"corr\" UV variable")?;
+            .context("no \"corr\" UV variable")?;
 
         let time: f64 = in_uv.get_scalar(time_var);
         let lst: f64 = in_uv.get_scalar(lst_var);
@@ -446,10 +446,7 @@ impl UvInflator {
         let mut keep_going = true;
 
         while keep_going {
-            keep_going = self
-                .in_uv
-                .next()
-                .with_context(|| "could not read UV data")?;
+            keep_going = self.in_uv.next().context("could not read UV data")?;
             self.in_n += 1;
             let new_time = self.in_uv.get_scalar(self.time_var);
             let cur_time = self.time; // borrowck annoyances

--- a/miriad/examples/uvblast.rs
+++ b/miriad/examples/uvblast.rs
@@ -35,15 +35,13 @@ fn main() {
 }
 
 fn inner(path: &OsStr) -> Result<i32, Error> {
-    let mut ds = rubbl_miriad::DataSet::open(path).with_context(|| "error opening dataset")?;
-    let mut uv = ds
-        .open_uv()
-        .with_context(|| "could not open as UV dataset")?;
+    let mut ds = rubbl_miriad::DataSet::open(path).context("error opening dataset")?;
+    let mut uv = ds.open_uv().context("could not open as UV dataset")?;
     let mib = uv.visdata_bytes() as f64 / (1024. * 1024.);
     let mut n = 0usize;
     let t0 = Instant::now();
 
-    while uv.next().with_context(|| "could not read UV data")? {
+    while uv.next().context("could not read UV data")? {
         n += 1
     }
 

--- a/miriad/examples/uvdump.rs
+++ b/miriad/examples/uvdump.rs
@@ -34,10 +34,8 @@ fn main() {
 }
 
 fn inner(path: &OsStr) -> Result<i32, Error> {
-    let mut ds = rubbl_miriad::DataSet::open(path).with_context(|| "error opening dataset")?;
-    let mut uv = ds
-        .open_uv()
-        .with_context(|| "could not open as UV dataset")?;
+    let mut ds = rubbl_miriad::DataSet::open(path).context("error opening dataset")?;
+    let mut uv = ds.open_uv().context("could not open as UV dataset")?;
     uv.dump_diagnostic(io::stdout())?;
     Ok(0)
 }

--- a/miriad/examples/uvdump.rs
+++ b/miriad/examples/uvdump.rs
@@ -1,7 +1,7 @@
 //! Decode the low-level details of MIRIAD UV data.
 
+use anyhow::{Context, Error};
 use clap::{Arg, Command};
-use failure::{Error, ResultExt};
 use std::ffi::{OsStr, OsString};
 use std::io;
 use std::process;
@@ -25,7 +25,7 @@ fn main() {
 
         Err(e) => {
             println!("fatal error while processing {}", path.to_string_lossy());
-            for cause in e.iter_chain() {
+            for cause in e.chain() {
                 println!("  caused by: {}", cause);
             }
             1
@@ -34,8 +34,10 @@ fn main() {
 }
 
 fn inner(path: &OsStr) -> Result<i32, Error> {
-    let mut ds = rubbl_miriad::DataSet::open(path).context("error opening dataset")?;
-    let mut uv = ds.open_uv().context("could not open as UV dataset")?;
+    let mut ds = rubbl_miriad::DataSet::open(path).with_context(|| "error opening dataset")?;
+    let mut uv = ds
+        .open_uv()
+        .with_context(|| "could not open as UV dataset")?;
     uv.dump_diagnostic(io::stdout())?;
     Ok(0)
 }

--- a/miriad/examples/uvheadervars.rs
+++ b/miriad/examples/uvheadervars.rs
@@ -34,13 +34,10 @@ fn main() {
 }
 
 fn inner(path: &OsStr) -> Result<i32, Error> {
-    let mut ds =
-        rubbl_miriad::DataSet::open(path).with_context(|| "error opening input dataset")?;
-    let mut uv = ds
-        .open_uv()
-        .with_context(|| "could not open input as UV dataset")?;
+    let mut ds = rubbl_miriad::DataSet::open(path).context("error opening input dataset")?;
+    let mut uv = ds.open_uv().context("could not open input as UV dataset")?;
 
-    uv.next().with_context(|| "could not read UV data")?;
+    uv.next().context("could not read UV data")?;
 
     for var in uv.variables() {
         let n = var.n_vals();

--- a/visdata/Cargo.toml
+++ b/visdata/Cargo.toml
@@ -17,4 +17,5 @@ Preliminary work on generic data structures for radio interferometric visibility
 rubbl_core = "thiscommit:2020-12-15:Fiequ0wa"
 
 [dependencies]
+anyhow = "^1.0"
 rubbl_core = { path = "../core", version ="0.0.0-dev.0"}

--- a/visdata/Cargo.toml
+++ b/visdata/Cargo.toml
@@ -17,5 +17,5 @@ Preliminary work on generic data structures for radio interferometric visibility
 rubbl_core = "thiscommit:2020-12-15:Fiequ0wa"
 
 [dependencies]
-anyhow = "^1.0"
+anyhow = "1.0.0"
 rubbl_core = { path = "../core", version ="0.0.0-dev.0"}

--- a/visdata/README.md
+++ b/visdata/README.md
@@ -2,3 +2,9 @@
 
 A preliminary effort at a generic interface for I/O on interferometric
 visibility data. Pretty much a placeholder at this point.
+
+See [the `rubbl_core` README on Crates.io][1] for a discussion of crate
+duplication issues that may arise with key dependencies such as [`ndarray`][2].
+
+[1]: https://crates.io/crates/rubbl_core/
+[2]: https://crates.io/crates/ndarray/

--- a/visdata/src/lib.rs
+++ b/visdata/src/lib.rs
@@ -6,7 +6,7 @@
 //! API currently maps quasi-directly onto the MIRIAD data model since those are
 //! the files I'm working with.
 
-use rubbl_core::Result;
+use anyhow::Error;
 
 /// A "feed pol(arization)" is the polarization component sampled by a
 /// particular receptor on an radio antenna.
@@ -115,7 +115,7 @@ impl BasePol {
 }
 
 pub trait VisStream {
-    fn next(&mut self) -> Result<bool>;
+    fn next(&mut self) -> Result<bool, Error>;
 
     fn basepol(&self) -> BasePol;
 }


### PR DESCRIPTION
... and a bunch of other small changes.

The commits themselves are well commented in terms of their purposes, but basically this work removes error handling with failure, instead using thiserror/anyhow, which is in widespread use in the Rust community.

It seems GitHub hasn't recognised that this is the same PR I submitted about 18 months ago; here's @pkgw's comment from that time: https://github.com/pkgw/rubbl/issues/148#issuecomment-809393559

I'm not sure I understand all the questions from the comment made on the previous PR, but I'll attempt to explain my thinking here.  Using enums instead of structs as error types means that functions can return a "family" of errors rather than one specific error.  It is possible to have a error struct contain a `String` and just pass that around, with the string being a human-readable message, and there's nothing necessarily wrong with this (indeed I think there's no single right way to do errors).  IMO it is better to have enums because then the errors can be typed, and if the caller wants to, the error variants can be matched and handled. I guess this is also possible with the string approach, but this is much looser than using enum variants.

FWIW I leverage the typed error approach heavily [here](https://github.com/MWATelescope/mwa_hyperdrive/blob/main/src/error.rs).

In most cases I expect that users don't have the time/effort to do this kind of fancy error handling, and because most errors are unrecoverable (e.g. your code wants to open MS table "DATA", but it isn't there, what else could you possibly do?), the `?` should work as one expects it to.

All this said, I have been lazy in my porting of the `miriad` code, where I just dump existing string errors into a catchall `Generic` error enum variant; this could obviously be expanded depending on how much you/others care.

In terms of extensibility; I think semver compatibility is something every library maintainer should consider high priority, regardless of how errors are handled, so adding new variants to an existing error enum should be considered as a breaking change, requiring a new release of a crate. If the "stringy" approach were employed instead, obviously more errors could be stuffed into a catchall variant, but I'd be careful about pulling the rug out from users attempting to handle error variants, even if they're not typed.

Finally, I'm not sure if `anyhow` supported backtraces at the time of my last PR, but it appears to do so now.  I haven't tested them or even used them, but the code compiles, so :shrug: 

If/when this PR is merged, it would be great to have a new release of rubbl and it's family of crates.  Thanks once again for your time!