### PR TITLE
casatables/examples/tableinfo.rs: fix arg parsing

### DIFF
--- a/casatables/examples/tableinfo.rs
+++ b/casatables/examples/tableinfo.rs
@@ -15,6 +15,7 @@ fn main() {
         .rubbl_notify_args()
         .arg(
             Arg::new("IN-TABLE")
+                .value_parser(clap::value_parser!(PathBuf))
                 .help("The path of the input data set")
                 .required(true)
                 .index(1),


### PR DESCRIPTION
Reported by @astrojhgu in #306.

Closes #306.