### PR TITLE
Update to ndarray 0.16 and improve casatables uninitialized data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,16 +248,24 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.15.6"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+checksum = "087ee1ca8a7c22830c2bba4a96ed8e72ce0968ae944349324d52522f66aa3944"
 dependencies = [
  "matrixmultiply",
  "num-complex",
  "num-integer",
  "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
  "rawpointer",
 ]
+
+[[package]]
+name = "never"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96aba5aa877601bb3f6dd6a63a969e1f82e60646e81e71b14496995e9853c91"
 
 [[package]]
 name = "num-complex"
@@ -322,6 +330,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcdd8420072e66d54a407b3316991fe946ce3ab1083a7f575b2463866624704d"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +386,7 @@ dependencies = [
  "cc",
  "clap",
  "ndarray",
+ "never",
  "rubbl_casatables_impl",
  "rubbl_core",
  "tempfile",
@@ -449,9 +473,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/casatables/Cargo.toml
+++ b/casatables/Cargo.toml
@@ -15,12 +15,13 @@ Interfacing to the CASA table format within the Rubbl framework.
 
 [package.metadata.internal_dep_versions]
 rubbl_casatables_impl = "thiscommit:2021-11-04:9Lgzrtq"
-rubbl_core = "thiscommit:2020-12-15:EiT8sa0a"
+rubbl_core = "thiscommit:2024-08-12:zKS3IWN"
 
 [dependencies]
-ndarray = "0.15.0"
-rubbl_casatables_impl = { version ="0.0.0-dev.0", path = "../casatables_impl" }
-rubbl_core = { version ="0.0.0-dev.0", path = "../core" }
+ndarray = "0.16.0"
+never = "0.1.0"
+rubbl_casatables_impl = { version = "0.0.0-dev.0", path = "../casatables_impl" }
+rubbl_core = { version = "0.0.0-dev.0", path = "../core" }
 thiserror = "1.0.63"
 
 [build-dependencies]
@@ -29,5 +30,7 @@ cc = { version = "1.1.10", features = ["parallel"] }
 [dev-dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.15", features = ["cargo"] }
-rubbl_core = { version ="0.0.0-dev.0", path = "../core", features = ["notifications"] }
+rubbl_core = { version = "0.0.0-dev.0", path = "../core", features = [
+    "notifications",
+] }
 tempfile = "3.12.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,9 @@ notifications = ["anyhow", "clap", "termcolor"]
 anyhow = { version = "1.0.86", features = ["backtrace"], optional = true }
 byteorder = "1.5.0"
 clap = { version = "4.5.15", features = ["cargo"], optional = true }
-ndarray = "0.15.0"  # see README and src/lib.rs for discussion of constraints here; update when this changes
-num-complex = "0.4.6"  # ditto
+# see README and src/lib.rs for discussion of constraints here; update when this changes:
+ndarray = "0.16.0"
+# ditto:
+num-complex = "0.4.6"
 termcolor = { version = "1.4.1", optional = true }
 thiserror = "1.0.63"

--- a/core/README.md
+++ b/core/README.md
@@ -14,7 +14,7 @@ also explicitly depend on:
 - [`anyhow`] 1.0 (optionally)
 - [`byteorder`] 1.4
 - [`clap`] 4.0 (optionally)
-- [`ndarray`] 0.15
+- [`ndarray`] 0.16
 - [`num-complex`] 0.4
 - [`termcolor`] 1.1 (optionally)
 - [`thiserror`] 1.0


### PR DESCRIPTION
Here we finally fix the warning about uninitialized data in our casatables array buffers. We need to tweak the CasaDataType trait a bit, but no one external should have been implementing it themselves, so that shouldn't be an issue. It took me some time to get the trait specifications right but in the end it's not too complicated.

@d3v-null Would you mind trying out this branch and double-checking that the code seems to be working in your applications? I think that I've got the semantics right, and hopefully the compiler will catch anything problematic, but it certainly wouldn't hurt to do some additional testing here.